### PR TITLE
Fix error on mobile when viewing pigallery2 with videos disabled

### DIFF
--- a/backend/middlewares/GalleryMWs.ts
+++ b/backend/middlewares/GalleryMWs.ts
@@ -97,7 +97,9 @@ export class GalleryMWs {
       if (cw.directory) {
         const removeVideos = (dir: DirectoryDTO) => {
           dir.media = dir.media.filter(m => !MediaDTO.isVideo(m));
-          dir.directories.forEach(d => removeVideos(d));
+          if (dir.directories) {
+            dir.directories.forEach(d => removeVideos(d));
+          }
         };
         removeVideos(cw.directory);
       }


### PR DESCRIPTION
Hi, thanks for creating pigallery2. Contributing back with a potential bug fix...

Issue:
1. Set up pigallery2 with videos settings disabled
2. Encountered this error while viewing on mobile (Chrome 72.0.3626.96 on Android 8.0.0). The gallery fails to load up; instead, just displays a loading image
```
2/10/2019, 2:26:38 AM[WARN] Handled error:
ErrorDTO {
  code: 9,
  message: 'Unknown server side error',
  details:
   TypeError: Cannot read property 'forEach' of undefined
       at removeVideos_1 (/pigallery2-release/backend/middlewares/GalleryMWs.js:131:37)
       at /pigallery2-release/backend/middlewares/GalleryMWs.js:131:67
       at Array.forEach (<anonymous>)
       at removeVideos_1 (/pigallery2-release/backend/middlewares/GalleryMWs.js:131:37)
       at GalleryMWs.cleanUpGalleryResults (/pigallery2-release/backend/middlewares/GalleryMWs.js:133:17)
       at Layer.handle [as handle_request] (/pigallery2-release/node_modules/express/lib/router/layer.js:95:5)
       at next (/pigallery2-release/node_modules/express/lib/router/route.js:137:13)
       at ThumbnailGeneratorMWs.addThumbnailInformation (/pigallery2-release/backend/middlewares/thumbnail/ThumbnailGeneratorMWs.js:95:16)
       at Layer.handle [as handle_request] (/pigallery2-release/node_modules/express/lib/router/layer.js:95:5)
       at next (/pigallery2-release/node_modules/express/lib/router/route.js:137:13) }
```
3. However, I don't get this error while viewing on desktop (Chrome 72.0.3626.81 on Ubuntu 18.04.1 LTS)