### PR TITLE
Remove .toString() from disk error handling

### DIFF
--- a/backend/model/threading/DiskMangerWorker.ts
+++ b/backend/model/threading/DiskMangerWorker.ts
@@ -116,7 +116,7 @@ export class DiskMangerWorker {
 
           return resolve(directory);
         } catch (err) {
-          return reject({error: err.toString()});
+          return reject({error: err});
         }
 
       });


### PR DESCRIPTION
For the most part, error messages look like:
```js
{ error: 
      { errno: -2,
        code: 'ENOENT',
        syscall: 'stat',
        path: '/data/path/stuff/place' } }
```

But `toString()` just turns it into `[object Object]`, which is quite useless as a log message.