### PR TITLE
Use ENV to set important paths

### DIFF
--- a/docker/alpine/Dockerfile.build
+++ b/docker/alpine/Dockerfile.build
@@ -16,16 +16,20 @@ RUN mkdir -p /app/data/config && \
 #-----------------------------------------
 FROM node:12-alpine3.11 as main
 WORKDIR /app
+ENV NODE_ENV=production \
+    CONFIG_FILE=/app/data/config/config.json \
+    DB_PATH=/app/data/db \
+    MEDIA_PATH=/app/data/images \
+    TEMP_PATH=/app/data/tmp
 # command line arg orverride the config.json with these settings
 ENTRYPOINT ["node", "./src/backend/index",  \
   # after a extensive job (like video converting), pigallery calls gc, to clean up everthing as fast as possible
   "--expose-gc", \
-  "--config-path=/app/data/config/config.json", \
-  "--Server-Database-dbFolder=/app/data/db", \
-  "--Server-Media-folder=/app/data/images", \
-  "--Server-Media-tempFolder=/app/data/tmp"]
+  "--config-path=$CONFIG_FILE", \
+  "--Server-Database-dbFolder=$DB_PATH", \
+  "--Server-Media-folder=$MEDIA_PATH", \
+  "--Server-Media-tempFolder=$TEMP_PATH"]
 EXPOSE 80
-ENV NODE_ENV=production
 RUN apk add --update-cache --repository https://alpine.global.ssl.fastly.net/alpine/v3.11/community/ \
     vips ffmpeg
 COPY --from=builder /app /app

--- a/docker/alpine/Dockerfile.build
+++ b/docker/alpine/Dockerfile.build
@@ -18,17 +18,14 @@ FROM node:12-alpine3.11 as main
 WORKDIR /app
 ENV NODE_ENV=production \
     CONFIG_FILE=/app/data/config/config.json \
-    DB_PATH=/app/data/db \
-    MEDIA_PATH=/app/data/images \
-    TEMP_PATH=/app/data/tmp
+    Server-Database-dbFolder=/app/data/db \
+    Server-Media-folder=/app/data/images \
+    Server-Media-tempFolder=/app/data/tmp
 # command line arg orverride the config.json with these settings
 ENTRYPOINT ["node", "./src/backend/index",  \
   # after a extensive job (like video converting), pigallery calls gc, to clean up everthing as fast as possible
   "--expose-gc", \
-  "--config-path=$CONFIG_FILE", \
-  "--Server-Database-dbFolder=$DB_PATH", \
-  "--Server-Media-folder=$MEDIA_PATH", \
-  "--Server-Media-tempFolder=$TEMP_PATH"]
+  "--config-path=$CONFIG_FILE"]
 EXPOSE 80
 RUN apk add --update-cache --repository https://alpine.global.ssl.fastly.net/alpine/v3.11/community/ \
     vips ffmpeg

--- a/docker/debian-stretch/Dockerfile.build
+++ b/docker/debian-stretch/Dockerfile.build
@@ -14,16 +14,20 @@ RUN mkdir -p /app/data/config && \
 #-----------------------------------------
 FROM node:12-stretch-slim as main
 WORKDIR /app
+ENV NODE_ENV=production \
+    CONFIG_FILE=/app/data/config/config.json \
+    DB_PATH=/app/data/db \
+    MEDIA_PATH=/app/data/images \
+    TEMP_PATH=/app/data/tmp
 # command line arg orverride the config.json with these settings
 ENTRYPOINT ["node", "./src/backend/index",  \
   # after a extensive job (like video converting), pigallery calls gc, to clean up everthing as fast as possible
   "--expose-gc", \
-  "--config-path=/app/data/config/config.json", \
-  "--Server-Database-dbFolder=/app/data/db", \
-  "--Server-Media-folder=/app/data/images", \
-  "--Server-Media-tempFolder=/app/data/tmp"]
+  "--config-path=$CONFIG_FILE", \
+  "--Server-Database-dbFolder=$DB_PATH", \
+  "--Server-Media-folder=$MEDIA_PATH", \
+  "--Server-Media-tempFolder=$TEMP_PATH"]
 EXPOSE 80
-ENV NODE_ENV=production
 RUN apt-get update && apt-get install -y ffmpeg
 COPY --from=builder /app /app
 VOLUME ["/app/data/config", "/app/data/db", "/app/data/images", "/app/data/tmp"]

--- a/docker/debian-stretch/Dockerfile.build
+++ b/docker/debian-stretch/Dockerfile.build
@@ -16,17 +16,14 @@ FROM node:12-stretch-slim as main
 WORKDIR /app
 ENV NODE_ENV=production \
     CONFIG_FILE=/app/data/config/config.json \
-    DB_PATH=/app/data/db \
-    MEDIA_PATH=/app/data/images \
-    TEMP_PATH=/app/data/tmp
+    Server-Database-dbFolder=/app/data/db \
+    Server-Media-folder=/app/data/images \
+    Server-Media-tempFolder=/app/data/tmp
 # command line arg orverride the config.json with these settings
 ENTRYPOINT ["node", "./src/backend/index",  \
   # after a extensive job (like video converting), pigallery calls gc, to clean up everthing as fast as possible
   "--expose-gc", \
-  "--config-path=$CONFIG_FILE", \
-  "--Server-Database-dbFolder=$DB_PATH", \
-  "--Server-Media-folder=$MEDIA_PATH", \
-  "--Server-Media-tempFolder=$TEMP_PATH"]
+  "--config-path=$CONFIG_FILE"]
 EXPOSE 80
 RUN apt-get update && apt-get install -y ffmpeg
 COPY --from=builder /app /app

--- a/docker/debian-stretch/selfcontained/Dockerfile
+++ b/docker/debian-stretch/selfcontained/Dockerfile
@@ -16,16 +16,13 @@ FROM node:12-stretch-slim
 WORKDIR /app
 ENV NODE_ENV=production \
     CONFIG_FILE=/app/data/config/config.json \
-    DB_PATH=/app/data/db \
-    MEDIA_PATH=/app/data/images \
-    TEMP_PATH=/app/data/tmp
+    Server-Database-dbFolder=/app/data/db \
+    Server-Media-folder=/app/data/images \
+    Server-Media-tempFolder=/app/data/tmp
 ENTRYPOINT ["npm", "start",  "--", \
   # after a extensive job (like video converting), pigallery calls gc, to clean up everthing as fast as possible
   "--expose-gc", \
-  "--config-path=$CONFIG_FILE", \
-  "--Server-Database-dbFolder=$DB_PATH", \
-  "--Server-Media-folder=$MEDIA_PATH", \
-  "--Server-Media-tempFolder=$TEMP_PATH"]
+  "--config-path=$CONFIG_FILE"]
 EXPOSE 80
 COPY --from=BUILDER /build/release /app
 VOLUME ["/app/data/config", "/app/data/db", "/app/data/images", "/app/data/tmp"]

--- a/docker/debian-stretch/selfcontained/Dockerfile
+++ b/docker/debian-stretch/selfcontained/Dockerfile
@@ -14,15 +14,19 @@ RUN set -x && npm install --unsafe-perm && \
 
 FROM node:12-stretch-slim
 WORKDIR /app
+ENV NODE_ENV=production \
+    CONFIG_FILE=/app/data/config/config.json \
+    DB_PATH=/app/data/db \
+    MEDIA_PATH=/app/data/images \
+    TEMP_PATH=/app/data/tmp
 ENTRYPOINT ["npm", "start",  "--", \
   # after a extensive job (like video converting), pigallery calls gc, to clean up everthing as fast as possible
   "--expose-gc", \
-  "--config-path=/app/data/config/config.json", \
-  "--Server-Database-dbFolder=/app/data/db", \
-  "--Server-Media-folder=/app/data/images", \
-  "--Server-Media-tempFolder=/app/data/tmp"]
+  "--config-path=$CONFIG_FILE", \
+  "--Server-Database-dbFolder=$DB_PATH", \
+  "--Server-Media-folder=$MEDIA_PATH", \
+  "--Server-Media-tempFolder=$TEMP_PATH"]
 EXPOSE 80
-ENV NODE_ENV=production
 COPY --from=BUILDER /build/release /app
 VOLUME ["/app/data/config", "/app/data/db", "/app/data/images", "/app/data/tmp"]
 HEALTHCHECK --interval=30s --timeout=10s --retries=4 --start-period=60s \


### PR DESCRIPTION
Makes it easier to change the options via ENV vars. Can be used to set the DB, IMAGE, TMP and CONF path.

