### PR TITLE
make app wait for db to start up first

### DIFF
--- a/docker/docker-compose/with-mysql/docker-compose.yml
+++ b/docker/docker-compose/with-mysql/docker-compose.yml
@@ -26,7 +26,7 @@ services:
 
   pigallery2:
     image: bpatrik/pigallery2:latest
-    command: --Server-Database-mysql-host=pigallery-db --Server-Database-mysql-username=pigallery2 --Server-Database-mysql-password=pigallery2_pass--Server-Database-mysql-database=pigallery2
+    command: sh -c 'bin/wait-for pigallery-db:3306 -- --Server-Database-mysql-host=pigallery-db --Server-Database-mysql-username=pigallery2 --Server-Database-mysql-password=pigallery2_pass--Server-Database-mysql-database=pigallery2'
     container_name: pigallery2
     environment:
       - NODE_ENV=production


### PR DESCRIPTION
Fix for #163 
Prevents using memory database if db is still starting up

The server still starts up on first start with a sqlite db, but once you configure it to use mysql from the GUI, it uses that. 