### PR TITLE
Update Dockerfiles

### DIFF
--- a/docker/alpine/Dockerfile.build
+++ b/docker/alpine/Dockerfile.build
@@ -14,7 +14,7 @@ RUN mkdir -p /app/data/config && \
 
 #-----------------MAIN--------------------
 #-----------------------------------------
-FROM node:12-alpine3.11 as main
+FROM node:12-alpine3.11 AS main
 WORKDIR /app
 ENV NODE_ENV=production \
     # overrides only the default value of the settings (the actualy value can be overwritten through config.json)
@@ -24,7 +24,6 @@ ENV NODE_ENV=production \
     # flagging dockerized environemnt
     PI_DOCKER=true
 
-
 EXPOSE 80
 RUN apk add --update-cache --repository https://alpine.global.ssl.fastly.net/alpine/v3.11/community/ \
     vips ffmpeg
@@ -33,7 +32,6 @@ VOLUME ["/app/data/config", "/app/data/db", "/app/data/images", "/app/data/tmp"]
 HEALTHCHECK --interval=40s --timeout=30s --retries=3 --start-period=60s \
   CMD wget --quiet --tries=1 --no-check-certificate --spider \
   http://localhost:80/heartbeat || exit 1
-
 
 # after a extensive job (like video converting), pigallery calls gc, to clean up everthing as fast as possible
 # Exec form entrypoint is need otherwise (using shell form) ENV variables are not properly passed down to the app

--- a/docker/debian-stretch/Dockerfile.build
+++ b/docker/debian-stretch/Dockerfile.build
@@ -12,7 +12,7 @@ RUN mkdir -p /app/data/config && \
 
 #-----------------MAIN--------------------
 #-----------------------------------------
-FROM node:12-stretch-slim as main
+FROM node:12-stretch-slim AS main
 WORKDIR /app
 ENV NODE_ENV=production \
     # overrides only the default value of the settings (the actualy value can be overwritten through config.json)
@@ -22,14 +22,11 @@ ENV NODE_ENV=production \
     # flagging dockerized environemnt
     PI_DOCKER=true
 
-# after a extensive job (like video converting), pigallery calls gc, to clean up everthing as fast as possible
-# This trick is needed as entrypoint in exec form does not support ENV variables
-# and in shell form ENV variables were not properly passed to pigallry2
-#RUN echo -e '#!/bin/bash \n node ./src/backend/index --expose-gc --config-path=${CONFIG_FILE}' > ./entrypoint.sh && \
-# chmod +x ./entrypoint.sh
-
 EXPOSE 80
-RUN apt-get update && apt-get install -y ffmpeg
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates wget ffmpeg \
+    && apt-get clean -q -y \
+    && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /app /app
 VOLUME ["/app/data/config", "/app/data/db", "/app/data/images", "/app/data/tmp"]
 HEALTHCHECK --interval=40s --timeout=30s --retries=3 --start-period=60s \

--- a/docker/debian-stretch/selfcontained/Dockerfile
+++ b/docker/debian-stretch/selfcontained/Dockerfile
@@ -1,32 +1,43 @@
-FROM node:12-stretch AS BUILDER
+#-----------------BUILDER-----------------
+#-----------------------------------------
+FROM node:12-stretch AS builder
 # LABEL maintainer="Patrik J. Braun"
 # copying only package{-lock}.json to make node_modules cachable
 RUN git clone https://github.com/bpatrik/pigallery2.git /build
 WORKDIR /build
-RUN set -x && npm install --unsafe-perm && \
-    mkdir -p /build/release/data/config && \
-    mkdir -p /build/release/data/db && \
-    mkdir -p /build/release/data/images && \
-    mkdir -p /build/release/data/tmp && \
-    npm run create-release && \
-    cd /build/release && npm install --unsafe-perm
+RUN npm install --unsafe-perm \
+    && mkdir -p /build/release/data/config \
+    && mkdir -p /build/release/data/db \
+    && mkdir -p /build/release/data/images \
+    && mkdir -p /build/release/data/tmp \
+    && npm run create-release \
+    && cd /build/release \
+    && npm install --unsafe-perm
 
-
-FROM node:12-stretch-slim
+#-----------------MAIN--------------------
+#-----------------------------------------
+FROM node:12-stretch-slim AS main
 WORKDIR /app
 ENV NODE_ENV=production \
-    CONFIG_FILE=/app/data/config/config.json \
-    Server-Database-dbFolder=/app/data/db \
-    Server-Media-folder=/app/data/images \
-    Server-Media-tempFolder=/app/data/tmp
-ENTRYPOINT ["npm", "start",  "--", \
-  # after a extensive job (like video converting), pigallery calls gc, to clean up everthing as fast as possible
-  "--expose-gc", \
-  "--config-path=$CONFIG_FILE"]
+    # overrides only the default value of the settings (the actualy value can be overwritten through config.json)
+    default-Server-Database-dbFolder=/app/data/db \
+    default-Server-Media-folder=/app/data/images \
+    default-Server-Media-tempFolder=/app/data/tmp \
+    # flagging dockerized environemnt
+    PI_DOCKER=true
+
 EXPOSE 80
-COPY --from=BUILDER /build/release /app
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates wget ffmpeg \
+    && apt-get clean -q -y \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /build/release /app
 VOLUME ["/app/data/config", "/app/data/db", "/app/data/images", "/app/data/tmp"]
-HEALTHCHECK --interval=30s --timeout=10s --retries=4 --start-period=60s \
+HEALTHCHECK --interval=40s --timeout=30s --retries=3 --start-period=60s \
   CMD wget --quiet --tries=1 --no-check-certificate --spider \
-  http://localhost:80 || exit 1
+  http://localhost:80/heartbeat || exit 1
+
+# after a extensive job (like video converting), pigallery calls gc, to clean up everthing as fast as possible
+# Exec form entrypoint is need otherwise (using shell form) ENV variables are not properly passed down to the app
+ENTRYPOINT ["node", "./src/backend/index", "--expose-gc",  "--config-path=/app/data/config/config.json"]
 


### PR DESCRIPTION
Some updates to the Dockerfiles

- added `wget` to Debian images (it was removed from the node base image, see https://github.com/nodejs/docker-node/issues/1185). Fixes #193 
- resynchronized the standalone Dockerfile with the one used for builds
- apt install without recommended packages
- clean apt cache after install to reduce image size a bit

Note:
- the edits to the two `Dockerfile.build` are simply intended to minimize the differences between all files (e.g. when using `diff` or `vimdiff`)
- I have only tested the standalone Dockerfile on my side, please test a bit on your side once the automated builds have completed.
- I have added the option `--no-install-recommends` to reduce the number of packages installed. It might (or might not) be an issue with video transcoding. I have tested that video transcoding runs without errors, but on a tiny sample. Please consider checking that nothing broke for wider use cases I could not test.