### PR TITLE
Fixes #219: Manifest for web app takes '.' as default if publicUrl is empty string

### DIFF
--- a/src/backend/routes/PublicRouter.ts
+++ b/src/backend/routes/PublicRouter.ts
@@ -105,7 +105,7 @@ export class PublicRouter {
           ],
           display: 'standalone',
           orientation: 'any',
-          start_url: Config.Client.publicUrl,
+          start_url: Config.Client.publicUrl === '' ? '.' : Config.Client.publicUrl,
           background_color: '#000000',
           theme_color: '#000000'
         });


### PR DESCRIPTION
In case `publicUrl` in the configuration is an empty string, then `start_url` for the `manifest.json` response is set to `.`. 