### PR TITLE
Fix gallery order issue

### DIFF
--- a/src/frontend/app/ui/gallery/gallery.component.ts
+++ b/src/frontend/app/ui/gallery/gallery.component.ts
@@ -172,12 +172,16 @@ export class GalleryComponent implements OnInit, OnDestroy {
     }
     switch (this._galleryService.sorting.value) {
       case SortingMethods.ascName:
-      case SortingMethods.ascDate:
         this.directories.sort((a: DirectoryDTO, b: DirectoryDTO) => compare()(a.name, b.name));
         break;
+      case SortingMethods.ascDate:
+        this.directories.sort((a: DirectoryDTO, b: DirectoryDTO) => compare()(a.lastModified, b.lastModified));
+        break;
       case SortingMethods.descName:
-      case SortingMethods.descDate:
         this.directories.sort((a: DirectoryDTO, b: DirectoryDTO) => compare({ order: 'desc' })(a.name, b.name));
+        break;
+      case SortingMethods.descDate:
+        this.directories.sort((a: DirectoryDTO, b: DirectoryDTO) => compare({ order: 'desc' })(a.lastModified, b.lastModified));
         break;
       case SortingMethods.random:
         this.rndService.setSeed(this.directories.length);

--- a/src/frontend/app/ui/gallery/grid/grid.gallery.component.ts
+++ b/src/frontend/app/ui/gallery/grid/grid.gallery.component.ts
@@ -28,6 +28,7 @@ import {SortingMethods} from '../../../../../common/entities/SortingMethods';
 import {MediaDTO} from '../../../../../common/entities/MediaDTO';
 import {QueryParams} from '../../../../../common/QueryParams';
 import {SeededRandomService} from '../../../model/seededRandom.service';
+import { compare } from 'natural-orderby';
 
 @Component({
   selector: 'app-gallery-grid',
@@ -230,26 +231,10 @@ export class GalleryGridComponent implements OnChanges, OnInit, AfterViewInit, O
   private sortPhotos() {
     switch (this.galleryService.sorting.value) {
       case SortingMethods.ascName:
-        this.media.sort((a: PhotoDTO, b: PhotoDTO) => {
-          if (a.name.toLowerCase() < b.name.toLowerCase()) {
-            return -1;
-          }
-          if (a.name.toLowerCase() > b.name.toLowerCase()) {
-            return 1;
-          }
-          return 0;
-        });
+        this.media.sort((a: PhotoDTO, b: PhotoDTO) => compare()(a.name, b.name));
         break;
       case SortingMethods.descName:
-        this.media.sort((a: PhotoDTO, b: PhotoDTO) => {
-          if (a.name.toLowerCase() < b.name.toLowerCase()) {
-            return 1;
-          }
-          if (a.name.toLowerCase() > b.name.toLowerCase()) {
-            return -1;
-          }
-          return 0;
-        });
+        this.media.sort((a: PhotoDTO, b: PhotoDTO) => compare({order: 'desc' })(a.name, b.name));
         break;
       case SortingMethods.ascDate:
         this.media.sort((a: PhotoDTO, b: PhotoDTO) => {


### PR DESCRIPTION
This PR fixes the order issue in the gallery while sorting directories/media files:  

* Add code so directories can be sorted by date  
The code in `src/frontend/app/ui/gallery/gallery.component.ts` shows that `SortingMethods.ascDate` and `SortingMethods.ascName` ( and `desc` as well ) are using the same code to sort the directories ( both sort by name in natural-order ).  I've added some code so directories now can be sorted by its `lastModified` attribute.  

* Add code so media files in a directories can be sorted in natural-order  
PR #224 added the code to sort the directories in natural-order, however the media files in directories are still using lexicographic-order. I've added some code in `src/frontend/app/ui/gallery/grid/grid.gallery.component.ts` to support natural-order for media files as well.  

Please do review this PR, since I'm not sure if the modification suits everyone needs. Discussion/suggestions are welcomed.
