### PR TITLE
CSS fix for truncated page titles on mobile

### DIFF
--- a/src/frontend/app/ui/login/login.component.css
+++ b/src/frontend/app/ui/login/login.component.css
@@ -1,7 +1,7 @@
 .title h1 {
   font-size: 80px;
   font-weight: bold;
-  white-space: nowrap;
+  text-align: center;
 }
 
 .title img {

--- a/src/frontend/app/ui/sharelogin/share-login.component.css
+++ b/src/frontend/app/ui/sharelogin/share-login.component.css
@@ -1,7 +1,7 @@
 .title h1 {
   font-size: 80px;
   font-weight: bold;
-  white-space: nowrap;
+  text-align: center;
 }
 
 .title img {


### PR DESCRIPTION
Closes #265 

Just a simple edit following what I suggested in #265 