### PR TITLE
Fix whitespace between Navbar and breadcrumbs

### DIFF
--- a/src/frontend/app/ui/frame/frame.component.css
+++ b/src/frontend/app/ui/frame/frame.component.css
@@ -2,10 +2,6 @@ nav {
   z-index: 999;
 }
 
-.navbar {
-  margin-bottom: 20px;
-}
-
 ng2-slim-loading-bar {
   /* display: block; */
   z-index: 999999;


### PR DESCRIPTION
There is a whitespace between the Navbar and breadcrumb/sort section. The change here is to remove the margin style that causes the white space.

Screenshot:
![Screenshot 2021-07-18 at 9 13 16 PM](https://user-images.githubusercontent.com/20453492/126102613-2dfa702e-06e2-4dae-b223-0b5ba7226e42.png)
