### PR TITLE
fix encoding non-ascii characters in detected face names

### DIFF
--- a/src/backend/model/threading/MetadataLoader.ts
+++ b/src/backend/model/threading/MetadataLoader.ts
@@ -278,7 +278,7 @@ export class MetadataLoader {
                     } else if (regionRoot.Area && regionRoot.Name && regionRoot.Type) {
 
                       const regionBox = regionRoot.Area.value;
-                      name = regionRoot.Name.value;
+                      name = decodeURIComponent(escape(regionRoot.Name.value));
                       type = regionRoot.Type.value;
                       box = createFaceBox(regionBox.w.value,
                         regionBox.h.value,


### PR DESCRIPTION
This is a fix [which was also applied in exif reader](https://github.com/mattiasw/ExifReader/pull/47/files#diff-d65f0e04e026c207d67b8b88660ba72716c0e5363af90c7355ea04d1b9b256d6R120) to properly handle UTF-8 characters in face names. The problem only occurs in `exiftool` generated metadata as atttributes are accesed by raw values there (the "lightroom" version of face meta is fine).

Here is an example photo to illustrate the problem: https://transfer.sh/15gTYWl/IMG_5910.jpg

Without patch:
![wrong](https://user-images.githubusercontent.com/150545/126850512-70647f78-ca37-4173-b362-acaeaddc47bb.jpg)

With patch:
![correct](https://user-images.githubusercontent.com/150545/126850516-f09edb93-e1a6-4381-9ef7-5506fdbd64d1.jpg)

