### PR TITLE
Allow admin user/password through environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,9 @@ npm start
 To configure it, run `PiGallery2` first to create `config.json` file, then edit it and restart.
 The app has a nice UI for settings, you may use that too. 
 
-Default user: `admin` pass: `admin`. (It is not possible to change the admin password, you need to create an other user and delete the default `admin` user, see  #220)
+Default user: `admin` pass: `admin`.
+
+**Important**: It is strongly recommended to change the default password by defining the `PI_ADMIN_PASSWORD` environment variable. Alternatively, you can use the `PI_ADMIN_PASSWORD_FILE` environment variable in order to read the password from a file. Similarly, you can change the default user with the `PI_ADMIN_USER` and `PI_ADMIN_USER_FILE` environment variables.
 
 **Note**: First run, you might have file access issues and port 80 issue, see [#115](https://github.com/bpatrik/pigallery2/issues/115).
 Running `npm start -- --Server-port=8080` will start the app on port 8080 that does not require `root`

--- a/docker/README.md
+++ b/docker/README.md
@@ -66,8 +66,9 @@ docker-compose up -d
 ```
 `-d` runs it as a daemon. Remove it, so you will see the logs. 
 
-After the containers are up and running, you go to `yourdomain.com` and log in with user: `admin` pass: `admin` and set up the page in the settings. 
-Full list of configuration options are available at the [MANPAGE.md](../MANPAGE.md).
+After the containers are up and running, you go to `yourdomain.com` and log in with user: `admin` pass: `admin` and set up the page in the settings. Full list of configuration options are available at the [MANPAGE.md](../MANPAGE.md).
+
+**Important**: It is strongly recommended to change the default password by defining the `PI_ADMIN_PASSWORD` environment variable. Alternatively, you can use the `PI_ADMIN_PASSWORD_FILE` environment variable in order to read the password from a file. Similarly, you can change the default user with the `PI_ADMIN_USER` and `PI_ADMIN_USER_FILE` environment variables.
 
 **Note:** `docker-compose.yml` contains `restart:always`, so the containers will be automatically started after reboot ([read more here](https://stackoverflow.com/questions/43671482/how-to-run-docker-compose-up-d-at-system-start-up)).
  
@@ -95,6 +96,8 @@ docker run \
 ```
 
 After the container is up and running, you go to `http://localhost` and log in with user: `admin` pass: `admin` and set up the page in the settings. 
+
+**Important**: It is strongly recommended to change the default password by defining the `PI_ADMIN_PASSWORD` environment variable. Alternatively, you can use the `PI_ADMIN_PASSWORD_FILE` environment variable in order to read the password from a file. Similarly, you can change the default user with the `PI_ADMIN_USER` and `PI_ADMIN_USER_FILE` environment variables.
 
 **Note**: even with `memory` db, pigallery2 creates a db file for storing user credentials (if enabled), so mounting (with `-v`) the `/app/data/db` folder is recommended.
 

--- a/src/backend/model/PasswordHelper.ts
+++ b/src/backend/model/PasswordHelper.ts
@@ -1,6 +1,42 @@
 import * as bcrypt from 'bcrypt';
+import * as fs from 'fs';
+import {Logger} from '../Logger';
+
+const LOG_TAG = '[PasswordHelper]';
 
 export class PasswordHelper {
+  private static readSecretFromEnvironment(varName: string, defaultValue: string,
+                                           warnOnDefaultValue: boolean) : string {
+    if (process.env[varName + '_FILE']) {
+      var secretText = fs.readFileSync(process.env[varName + '_FILE'], 'utf-8');
+      var secretLines = secretText.split(/\r?\n/).filter(i => i);
+      if (secretLines.length !== 1) {
+        throw new Error('The file pointed to by environment variable \'' + varName + '_FILE\'' +
+          ' must have a single non-empty line');
+      }
+      return secretLines[0];
+    } else if (process.env[varName]) {
+      return process.env[varName];
+    } else if (defaultValue) {
+      if (warnOnDefaultValue) {
+        Logger.warn(LOG_TAG, 'Environment variable \'' + varName + '\' not defined' +
+          ', using default value \'' + defaultValue + '\'');
+      }
+      return defaultValue;
+    } else {
+      throw new Error('Environment variable \'' + varName + '\' must be defined');
+    }
+  }
+
+  public static getDefaultAdminUser(): string {
+    return PasswordHelper.readSecretFromEnvironment('PI_ADMIN_USER', 'admin', false);
+  }
+
+  public static getDefaultAdminPassword(): string {
+    // TODO: remove defaults
+    return PasswordHelper.readSecretFromEnvironment('PI_ADMIN_PASSWORD', 'admin', true);
+  }
+
   public static cryptPassword(password: string): string {
     const salt = bcrypt.genSaltSync(9);
     return bcrypt.hashSync(password, salt);

--- a/src/backend/model/database/memory/UserManager.ts
+++ b/src/backend/model/database/memory/UserManager.ts
@@ -24,8 +24,11 @@ export class UserManager implements IUserManager {
 
     if (!this.db.users) {
       this.db.users = [];
-      // TODO: remove defaults
-      this.createUser({name: 'admin', password: 'admin', role: UserRoles.Admin} as UserDTO);
+      this.createUser({
+        name: PasswordHelper.getDefaultAdminUser(),
+        password: PasswordHelper.getDefaultAdminPassword(),
+        role: UserRoles.Admin
+      } as UserDTO);
     }
     this.saveDB();
 

--- a/src/backend/model/database/sql/SQLConnection.ts
+++ b/src/backend/model/database/sql/SQLConnection.ts
@@ -100,8 +100,8 @@ export class SQLConnection {
     const admins = await userRepository.find({role: UserRoles.Admin});
     if (admins.length === 0) {
       const a = new UserEntity();
-      a.name = 'admin';
-      a.password = PasswordHelper.cryptPassword('admin');
+      a.name = PasswordHelper.getDefaultAdminUser();
+      a.password = PasswordHelper.cryptPassword(PasswordHelper.getDefaultAdminPassword());
       a.role = UserRoles.Admin;
       await userRepository.save(a);
     }


### PR DESCRIPTION
Allows specifying the default admin user / password through the `PI_ADMIN_USER` / `PI_ADMIN_PASSWORD` (or `PI_ADMIN_USER_FILE` / `PI_ADMIN_PASSWORD_FILE`) environment variables, and update the documentation to strongly recommend changing the default password.
(The reference to the possibility to remove the default admin user has been removed, as it allows the possibility of an insecure setup if the database were to be recreated).

Fixes: #220