### PR TITLE
Typo: replace "an other" with "another"

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ npm start
 To configure it, run `PiGallery2` first to create `config.json` file, then edit it and restart.
 The app has a nice UI for settings, you may use that too. 
 
-Default user: `admin` pass: `admin`. (It is not possible to change the admin password, you need to create an other user and delete the default `admin` user, see  #220)
+Default user: `admin` pass: `admin`. (It is not possible to change the admin password, you need to create another user and delete the default `admin` user, see  #220)
 
 **Note**: First run, you might have file access issues and port 80 issue, see [#115](https://github.com/bpatrik/pigallery2/issues/115).
 Running `npm start -- --Server-port=8080` will start the app on port 8080 that does not require `root`

--- a/docs/index.html
+++ b/docs/index.html
@@ -139,7 +139,7 @@
 
           keyword:"house"<br/>
           caption:"caption"<br/>
-          directory:"dir name/an other dir"<br/>
+          directory:"dir name/another dir"<br/>
           file_name:"img.jpg",<br/>
           person:"John",<br/>
           position:"USA" # use city, state, country names<br/>

--- a/src/backend/model/jobs/JobManager.ts
+++ b/src/backend/model/jobs/JobManager.ts
@@ -59,7 +59,7 @@ export class JobManager implements IJobManager, IJobListener {
       (allowParallelRun === false && this.JobRunning === true) ||
       this.JobNoParallelRunning === true
     ) {
-      throw new Error("Can't start this job while an other is running");
+      throw new Error("Can't start this job while another is running");
     }
 
     const t = this.findJob(jobName);

--- a/src/frontend/app/ui/settings/jobs/jobs.settings.component.html
+++ b/src/frontend/app/ui/settings/jobs/jobs.settings.component.html
@@ -141,7 +141,7 @@
                       [(ngModel)]="schedule.allowParallelRun">
                     </bSwitch>
                     <small class="form-text text-muted"
-                           i18n>Enables the job to start even if an other job is already running.
+                           i18n>Enables the job to start even if another job is already running.
                     </small>
                   </div>
                 </div>

--- a/src/frontend/translate/messages.cn.xlf
+++ b/src/frontend/translate/messages.cn.xlf
@@ -1961,7 +1961,7 @@
         <target>允许并行运行</target>
       </trans-unit>
       <trans-unit id="6820090689099376148" datatype="html">
-        <source>Enables the job to start even if an other job is already running. </source>
+        <source>Enables the job to start even if another job is already running. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/frontend/app/ui/settings/jobs/jobs.settings.component.html</context>
           <context context-type="linenumber">143,144</context>

--- a/src/frontend/translate/messages.de.xlf
+++ b/src/frontend/translate/messages.de.xlf
@@ -1961,7 +1961,7 @@
         <target>parallelen Durchlauf zulassen</target>
       </trans-unit>
       <trans-unit id="6820090689099376148" datatype="html">
-        <source>Enables the job to start even if an other job is already running. </source>
+        <source>Enables the job to start even if another job is already running. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/frontend/app/ui/settings/jobs/jobs.settings.component.html</context>
           <context context-type="linenumber">143,144</context>

--- a/src/frontend/translate/messages.en.xlf
+++ b/src/frontend/translate/messages.en.xlf
@@ -1961,12 +1961,12 @@
         <target>Allow parallel run</target>
       </trans-unit>
       <trans-unit id="6820090689099376148" datatype="html">
-        <source>Enables the job to start even if an other job is already running. </source>
+        <source>Enables the job to start even if another job is already running. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/frontend/app/ui/settings/jobs/jobs.settings.component.html</context>
           <context context-type="linenumber">143,144</context>
         </context-group>
-        <target>Enables the job to start even if an other job is already running.</target>
+        <target>Enables the job to start even if another job is already running.</target>
       </trans-unit>
       <trans-unit id="5242498003738057671" datatype="html">
         <source>';' separated integers. </source>

--- a/src/frontend/translate/messages.es.xlf
+++ b/src/frontend/translate/messages.es.xlf
@@ -1961,7 +1961,7 @@
         <target>Permitir la ejecución en paralelo</target>
       </trans-unit>
       <trans-unit id="6820090689099376148" datatype="html">
-        <source>Enables the job to start even if an other job is already running. </source>
+        <source>Enables the job to start even if another job is already running. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/frontend/app/ui/settings/jobs/jobs.settings.component.html</context>
           <context context-type="linenumber">143,144</context>

--- a/src/frontend/translate/messages.fr.xlf
+++ b/src/frontend/translate/messages.fr.xlf
@@ -1961,7 +1961,7 @@
         <target>Autoriser exécution parallèle</target>
       </trans-unit>
       <trans-unit id="6820090689099376148" datatype="html">
-        <source>Enables the job to start even if an other job is already running. </source>
+        <source>Enables the job to start even if another job is already running. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/frontend/app/ui/settings/jobs/jobs.settings.component.html</context>
           <context context-type="linenumber">143,144</context>

--- a/src/frontend/translate/messages.hu.xlf
+++ b/src/frontend/translate/messages.hu.xlf
@@ -1961,7 +1961,7 @@
         <target>Párhuzamos futtatás</target>
       </trans-unit>
       <trans-unit id="6820090689099376148" datatype="html">
-        <source>Enables the job to start even if an other job is already running. </source>
+        <source>Enables the job to start even if another job is already running. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/frontend/app/ui/settings/jobs/jobs.settings.component.html</context>
           <context context-type="linenumber">143,144</context>

--- a/src/frontend/translate/messages.id.xlf
+++ b/src/frontend/translate/messages.id.xlf
@@ -1961,7 +1961,7 @@
         <target>Ijinkan menjalankan paralel</target>
       </trans-unit>
       <trans-unit id="6820090689099376148" datatype="html">
-        <source>Enables the job to start even if an other job is already running. </source>
+        <source>Enables the job to start even if another job is already running. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/frontend/app/ui/settings/jobs/jobs.settings.component.html</context>
           <context context-type="linenumber">143,144</context>

--- a/src/frontend/translate/messages.it.xlf
+++ b/src/frontend/translate/messages.it.xlf
@@ -1961,7 +1961,7 @@
         <target state="translated">Consentire il funzionamento in parallelo</target>
       </trans-unit>
       <trans-unit id="6820090689099376148" datatype="html">
-        <source>Enables the job to start even if an other job is already running. </source>
+        <source>Enables the job to start even if another job is already running. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/frontend/app/ui/settings/jobs/jobs.settings.component.html</context>
           <context context-type="linenumber">143,144</context>

--- a/src/frontend/translate/messages.pl.xlf
+++ b/src/frontend/translate/messages.pl.xlf
@@ -1961,7 +1961,7 @@
         <target>Równoczesne wykonanie zadań</target>
       </trans-unit>
       <trans-unit id="6820090689099376148" datatype="html">
-        <source>Enables the job to start even if an other job is already running. </source>
+        <source>Enables the job to start even if another job is already running. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/frontend/app/ui/settings/jobs/jobs.settings.component.html</context>
           <context context-type="linenumber">143,144</context>

--- a/src/frontend/translate/messages.ro.xlf
+++ b/src/frontend/translate/messages.ro.xlf
@@ -1961,12 +1961,12 @@
         <target>Allow parallel run</target>
       </trans-unit>
       <trans-unit id="6820090689099376148" datatype="html">
-        <source>Enables the job to start even if an other job is already running. </source>
+        <source>Enables the job to start even if another job is already running. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/frontend/app/ui/settings/jobs/jobs.settings.component.html</context>
           <context context-type="linenumber">143,144</context>
         </context-group>
-        <target>Enables the job to start even if an other job is already running.</target>
+        <target>Enables the job to start even if another job is already running.</target>
       </trans-unit>
       <trans-unit id="5242498003738057671" datatype="html">
         <source>';' separated integers. </source>

--- a/src/frontend/translate/messages.ru.xlf
+++ b/src/frontend/translate/messages.ru.xlf
@@ -1961,12 +1961,12 @@
         <target>Allow parallel run</target>
       </trans-unit>
       <trans-unit id="6820090689099376148" datatype="html">
-        <source>Enables the job to start even if an other job is already running. </source>
+        <source>Enables the job to start even if another job is already running. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/frontend/app/ui/settings/jobs/jobs.settings.component.html</context>
           <context context-type="linenumber">143,144</context>
         </context-group>
-        <target>Enables the job to start even if an other job is already running.</target>
+        <target>Enables the job to start even if another job is already running.</target>
       </trans-unit>
       <trans-unit id="5242498003738057671" datatype="html">
         <source>';' separated integers. </source>

--- a/src/frontend/translate/messages.sv.xlf
+++ b/src/frontend/translate/messages.sv.xlf
@@ -1961,7 +1961,7 @@
         <target>Tillåt parallell körning</target>
       </trans-unit>
       <trans-unit id="6820090689099376148" datatype="html">
-        <source>Enables the job to start even if an other job is already running. </source>
+        <source>Enables the job to start even if another job is already running. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/frontend/app/ui/settings/jobs/jobs.settings.component.html</context>
           <context context-type="linenumber">143,144</context>


### PR DESCRIPTION
Replace instances of "an other" with "another" throughout the project.

This also touches translation files, which, I don't know if that causes negative effects in tooling.