### PR TITLE
Added code to render title (object_name) instead of filename.

### DIFF
--- a/benchmark/BenchmarkRunner.ts
+++ b/benchmark/BenchmarkRunner.ts
@@ -164,6 +164,7 @@ export class BenchmarkRunner {
 
       any_text: 'any-text',
       keyword: 'keyword',
+      title: 'title',
       caption: 'caption',
       directory: 'directory',
       file_name: 'file-name',

--- a/src/backend/model/database/sql/SearchManager.ts
+++ b/src/backend/model/database/sql/SearchManager.ts
@@ -241,6 +241,31 @@ export class SearchManager implements ISQLSearchManager {
 
     if (
       type === SearchQueryTypes.any_text ||
+      type === SearchQueryTypes.title
+    ) {
+      partialResult.push(
+        this.encapsulateAutoComplete(
+          (
+            await photoRepository
+              .createQueryBuilder('media')
+              .select('DISTINCT(media.metadata.title) as title')
+              .where(
+                'media.metadata.title LIKE :text COLLATE ' + SQL_COLLATE,
+                {text: '%' + text + '%'}
+              )
+              .limit(
+                Config.Client.Search.AutoComplete.targetItemsPerCategory * 2
+              )
+              .getRawMany()
+          ).map((r) => r.title),
+          SearchQueryTypes.title
+        )
+      );
+    }
+
+
+    if (
+      type === SearchQueryTypes.any_text ||
       type === SearchQueryTypes.directory
     ) {
       partialResult.push(

--- a/src/backend/model/database/sql/enitites/MediaEntity.ts
+++ b/src/backend/model/database/sql/enitites/MediaEntity.ts
@@ -101,6 +101,9 @@ export class PositionMetaDataEntity implements PositionMetaData {
 
 export class MediaMetadataEntity implements MediaMetadata {
   @Column('text')
+  title: string;
+
+  @Column('text')
   caption: string;
 
   @Column((type) => MediaDimensionEntity)

--- a/src/backend/model/threading/MetadataLoader.ts
+++ b/src/backend/model/threading/MetadataLoader.ts
@@ -243,6 +243,9 @@ export class MetadataLoader {
             if (iptcData.caption) {
               metadata.caption = iptcData.caption.replace(/\0/g, '').trim();
             }
+            if (iptcData.object_name) {
+              metadata.title = iptcData.object_name.replace(/\0/g, '').trim();
+            }
             if (Array.isArray(iptcData.keywords)) {
               metadata.keywords = iptcData.keywords;
             }

--- a/src/common/SearchQueryParser.ts
+++ b/src/common/SearchQueryParser.ts
@@ -37,6 +37,7 @@ export interface QueryKeywords {
   from: string;
   to: string;
   any_text: string;
+  title: string;
   caption: string;
   directory: string;
   file_name: string;
@@ -61,6 +62,7 @@ export const defaultQueryKeywords: QueryKeywords = {
 
   any_text: 'any-text',
   keyword: 'keyword',
+  title: 'title',
   caption: 'caption',
   directory: 'directory',
   file_name: 'file-name',
@@ -521,6 +523,7 @@ export class SearchQueryParser {
       case SearchQueryTypes.person:
       case SearchQueryTypes.position:
       case SearchQueryTypes.keyword:
+      case SearchQueryTypes.title:
       case SearchQueryTypes.caption:
       case SearchQueryTypes.file_name:
       case SearchQueryTypes.directory:

--- a/src/common/config/public/ClientConfig.ts
+++ b/src/common/config/public/ClientConfig.ts
@@ -151,6 +151,8 @@ export class ClientOtherConfig {
   @ConfigProperty()
   captionFirstNaming: boolean = false; // shows the caption instead of the filename in the photo grid
   @ConfigProperty()
+  titleFirstNaming: boolean = false; // shows the title instead of the filename in the photo grid
+  @ConfigProperty()
   enableDownloadZip: boolean = false;
   @ConfigProperty({
     description:

--- a/src/common/entities/PhotoDTO.ts
+++ b/src/common/entities/PhotoDTO.ts
@@ -28,6 +28,7 @@ export interface FaceRegion {
 
 export interface PhotoMetadata extends MediaMetadata {
   rating?: 0 | 1 | 2 | 3 | 4 | 5;
+  title?: string;
   caption?: string;
   keywords?: string[];
   cameraData?: CameraMetadata;

--- a/src/common/entities/SearchQueryDTO.ts
+++ b/src/common/entities/SearchQueryDTO.ts
@@ -20,6 +20,7 @@ export enum SearchQueryTypes {
 
   // TEXT search types
   any_text = 100,
+  title,
   caption,
   directory,
   file_name,
@@ -35,6 +36,7 @@ export const ListSearchQueryTypes = [
 ];
 export const TextSearchQueryTypes = [
   SearchQueryTypes.any_text,
+  SearchQueryTypes.title,
   SearchQueryTypes.caption,
   SearchQueryTypes.directory,
   SearchQueryTypes.file_name,
@@ -117,6 +119,7 @@ export const SearchQueryDTOUtils = {
       case SearchQueryTypes.person:
       case SearchQueryTypes.position:
       case SearchQueryTypes.keyword:
+      case SearchQueryTypes.title:
       case SearchQueryTypes.caption:
       case SearchQueryTypes.file_name:
       case SearchQueryTypes.directory:
@@ -168,6 +171,7 @@ export interface TextSearch extends NegatableSearchQuery {
     | SearchQueryTypes.person
     | SearchQueryTypes.keyword
     | SearchQueryTypes.position
+    | SearchQueryTypes.title
     | SearchQueryTypes.caption
     | SearchQueryTypes.file_name
     | SearchQueryTypes.directory;

--- a/src/frontend/app/ui/gallery/filter/filter.service.ts
+++ b/src/frontend/app/ui/gallery/filter/filter.service.ts
@@ -56,6 +56,11 @@ export class FilterService {
       isArrayValue: false,
     },
     {
+      name: $localize`Title`,
+      mapFn: (m: PhotoDTO): string => m.metadata.title,
+      renderType: FilterRenderType.enum,
+    },
+    {
       name: $localize`Caption`,
       mapFn: (m: PhotoDTO): string => m.metadata.caption,
       renderType: FilterRenderType.enum,

--- a/src/frontend/app/ui/gallery/grid/photo/photo.grid.gallery.component.ts
+++ b/src/frontend/app/ui/gallery/grid/photo/photo.grid.gallery.component.ts
@@ -60,10 +60,17 @@ export class GalleryPhotoComponent implements IRenderable, OnInit, OnDestroy {
   }
 
   get Title(): string {
-    if (Config.Client.Other.captionFirstNaming === false) {
-      return this.gridMedia.media.name;
+    if (Config.Client.Other.titleFirstNaming === true && (this.gridMedia.media as PhotoDTO).metadata.title) {
+      if ((this.gridMedia.media as PhotoDTO).metadata.title.length > 20) {
+        return (
+          (this.gridMedia.media as PhotoDTO).metadata.title.substring(0, 17) +
+          '...'
+        );
+      }
+      return (this.gridMedia.media as PhotoDTO).metadata.title;
     }
-    if ((this.gridMedia.media as PhotoDTO).metadata.caption) {
+
+    if (Config.Client.Other.captionFirstNaming === true && (this.gridMedia.media as PhotoDTO).metadata.caption) {
       if ((this.gridMedia.media as PhotoDTO).metadata.caption.length > 20) {
         return (
           (this.gridMedia.media as PhotoDTO).metadata.caption.substring(0, 17) +
@@ -72,6 +79,7 @@ export class GalleryPhotoComponent implements IRenderable, OnInit, OnDestroy {
       }
       return (this.gridMedia.media as PhotoDTO).metadata.caption;
     }
+ 
     return this.gridMedia.media.name;
   }
 

--- a/src/frontend/app/ui/gallery/lightbox/controls/controls.lightbox.gallery.component.ts
+++ b/src/frontend/app/ui/gallery/lightbox/controls/controls.lightbox.gallery.component.ts
@@ -109,7 +109,7 @@ export class ControlsLightboxComponent implements OnDestroy, OnInit, OnChanges {
     if (!this.activePhoto) {
       return null;
     }
-    return (this.activePhoto.gridMedia.media as PhotoDTO).metadata.caption;
+    return (this.activePhoto.gridMedia.media as PhotoDTO).metadata.title;
   }
 
   public containerWidth(): void {

--- a/src/frontend/app/ui/gallery/lightbox/lightbox.gallery.component.ts
+++ b/src/frontend/app/ui/gallery/lightbox/lightbox.gallery.component.ts
@@ -79,7 +79,7 @@ export class GalleryLightboxComponent implements OnDestroy, OnInit {
     if (!this.activePhoto) {
       return null;
     }
-    return (this.activePhoto.gridMedia.media as PhotoDTO).metadata.caption;
+    return (this.activePhoto.gridMedia.media as PhotoDTO).metadata.title;
   }
 
   public toggleFullscreen(): void {

--- a/src/frontend/app/ui/gallery/search/search-field-base/search-field-base.gallery.component.html
+++ b/src/frontend/app/ui/gallery/search/search-field-base/search-field-base.gallery.component.html
@@ -36,6 +36,7 @@
          *ngFor="let item of autoCompleteRenders; let i = index">
       <div>
                     <span [ngSwitch]="item.type">
+                      <span *ngSwitchCase="SearchQueryTypes.title" class="oi oi-image"></span>
                       <span *ngSwitchCase="SearchQueryTypes.caption" class="oi oi-image"></span>
                       <span *ngSwitchCase="SearchQueryTypes.directory" class="oi oi-folder"></span>
                       <span *ngSwitchCase="SearchQueryTypes.file_name" class="oi oi-image"></span>

--- a/src/frontend/app/ui/gallery/search/search-query-parser.service.ts
+++ b/src/frontend/app/ui/gallery/search/search-query-parser.service.ts
@@ -23,6 +23,7 @@ export class SearchQueryParserService {
 
     any_text: 'any-text',
     keyword: 'keyword',
+    title: 'title',
     caption: 'caption',
     directory: 'directory',
     file_name: 'file-name',

--- a/src/frontend/app/ui/settings/other/other.settings.component.html
+++ b/src/frontend/app/ui/settings/other/other.settings.component.html
@@ -54,6 +54,13 @@
       </app-settings-entry>
 
       <app-settings-entry
+        name="Title first naming"
+        description="Show the title (IPTC 5) tags from the EXIF data instead of the filenames."
+        i18n-description i18n-name
+        [ngModel]="states.Client.titleFirstNaming">
+      </app-settings-entry>
+
+      <app-settings-entry
         name="Caption first naming"
         description="Show the caption (IPTC 120) tags from the EXIF data instead of the filenames."
         i18n-description i18n-name


### PR DESCRIPTION
Addressing Feature request: https://github.com/bpatrik/pigallery2/issues/487

I've added IPTC "title" (object_name) as an option to replace filename, in the same way caption can be used.
My workflow comes almost exclusively from Lightroom, and Title is often what I use as a short phrase for the photo.
(just seems more natural in the Lightroom metadata panel).

I don't know how to create translations, so that part is missing.

(sorry about the misfire on the first request, there was a critical error that I missed in visual testing, and this should be cleaner).

This is my first/second pull request to a public project, and I'm learning node on the fly - so a careful review is warranted.  Thanks for your time!
