### PR TITLE
Update the metadata on test image to match current implementation

### DIFF
--- a/test/backend/assets/date_issue.json
+++ b/test/backend/assets/date_issue.json
@@ -1,7 +1,7 @@
 {
   "cameraData": {
     "ISO": 500,
-    "exposure": 0.0333,
+    "exposure": 0.033333,
     "fStop": 2,
     "focalLength": 2.96,
     "make": "HUAWEI",

--- a/test/backend/assets/orientation/broken_orientation_exif.json
+++ b/test/backend/assets/orientation/broken_orientation_exif.json
@@ -10,7 +10,7 @@
     "make": "Google",
     "ISO": 116,
     "focalLength": 4.442,
-    "exposure": 0.0083,
+    "exposure": 0.008335,
     "fStop": 1.8
   },
   "positionData": {

--- a/test/backend/assets/test image öüóőúéáű-.,.json
+++ b/test/backend/assets/test image öüóőúéáű-.,.json
@@ -1,7 +1,7 @@
 {
   "cameraData": {
     "ISO": 3200,
-    "exposure": 0.0013,
+    "exposure": 0.00125,
     "fStop": 5.6,
     "focalLength": 85,
     "lens": "EF-S15-85mm f/3.5-5.6 IS USM",

--- a/test/backend/assets/xmp/xmp_subject.json
+++ b/test/backend/assets/xmp/xmp_subject.json
@@ -1,7 +1,7 @@
 {
   "cameraData": {
     "ISO": 50,
-    "exposure": 0.0078,
+    "exposure": 0.007752,
     "fStop": 2.4,
     "focalLength": 4.32,
     "make": "samsung",


### PR DESCRIPTION
Good day.

I noticed the changes introduced by #536 did not update the test cases for parsing image metadata. Since #536 increased the number of decimal digits, the `exposure` attribute parsed from the images may have different values compared to the existing test data. Therefore, I made this PR to update the metadata on the test data.