### PR TITLE
The spaces for ffmpeg custom options are strict.

### DIFF
--- a/src/common/config/private/PrivateConfig.ts
+++ b/src/common/config/private/PrivateConfig.ts
@@ -768,7 +768,7 @@ export class VideoTranscodingConfig {
     tags: {
       name: $localize`Custom Output Options`,
       priority: ConfigPriority.underTheHood,
-      hint: '-pass 2; -minrate 1M; -maxrate 1M; -bufsize 2M',
+      hint: '-pass 2;-minrate 1M;-maxrate 1M;-bufsize 2M',
       uiAllowSpaces: true
     },
     description: $localize`It will be sent to ffmpeg as it is, as custom output options.`,


### PR DESCRIPTION
After some debugging, the custom options for fluent-ffmpeg are strict with spaces. We cannot have prefix or suffix spaces. The hint is confusing because it shows a space ` ` after semicolon `;`.