### PR TITLE
Redirect ffmpeg output to logger.

### DIFF
--- a/src/backend/model/threading/VideoConverterWorker.ts
+++ b/src/backend/model/threading/VideoConverterWorker.ts
@@ -55,7 +55,7 @@ export class VideoConverterWorker {
         })
         .on('stderr', function (line: string) {
           // Although this is under `stderr` event, all of ffmpeg output come here.
-          Logger.debug(line);
+          Logger.debug('[FFmpeg] ' + line);
         });
 
       // set custom input options

--- a/src/backend/model/threading/VideoConverterWorker.ts
+++ b/src/backend/model/threading/VideoConverterWorker.ts
@@ -52,6 +52,10 @@ export class VideoConverterWorker {
         })
         .on('error', (e: any) => {
           reject('[FFmpeg] ' + e.toString() + ' executed: ' + executedCmd);
+        })
+        .on('stderr', function (line: string) {
+          // Although this is under `stderr` event, all of ffmpeg output come here.
+          Logger.debug(line);
         });
 
       // set custom input options


### PR DESCRIPTION
This is something with #597 

Without any ffmpeg output, I spend hours on investigating why my custom options are not working. I cannot find the logs in UI output or command line output. This change will redirect ALL OF ffmpeg output to pigallery2's logger.

Warning: ffmpeg will output tons of information and bump your output. 

https://www.npmjs.com/package/fluent-ffmpeg#stderr-ffmpeg-output