### PR TITLE
docs: fix text-align in list

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -127,6 +127,10 @@ body {
   text-align: left;
 }
 
+ul {
+  text-align: left;
+}
+
 hr {
   background: white;
   margin-top: 0;
@@ -140,5 +144,3 @@ hr {
 .banner-photo {
   margin-bottom: 30px;
 }
-
-


### PR DESCRIPTION
The list is displayed in a weird way in the “All features:” section of https://bpatrik.github.io/pigallery2/ :

> ![image](https://github.com/bpatrik/pigallery2/assets/2071331/f3998225-32e9-4c09-821a-d91e2d8f0950)

This PR restore the `text-align` so that it's easier to read:

> ![image](https://github.com/bpatrik/pigallery2/assets/2071331/9e3d8b60-7dad-48d3-9c80-89da4f6f74a1)
