### PR TITLE
Add XMP sidecar support in backend for video files

### DIFF
--- a/demo/images/IMG_5910.jpg.xmp
+++ b/demo/images/IMG_5910.jpg.xmp
@@ -1,0 +1,406 @@
+<?xpacket begin='﻿' id='W5M0MpCehiHzreSzNTczkc9d'?>
+<x:xmpmeta xmlns:x='adobe:ns:meta/' x:xmptk='Image::ExifTool 12.69'>
+<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
+
+ <rdf:Description rdf:about=''
+  xmlns:Iptc4xmpCore='http://iptc.org/std/Iptc4xmpCore/1.0/xmlns/'>
+  <Iptc4xmpCore:CountryCode>US</Iptc4xmpCore:CountryCode>
+ </rdf:Description>
+
+ <rdf:Description rdf:about=''
+  xmlns:MicrosoftPhoto='http://ns.microsoft.com/photo/1.0'>
+  <MicrosoftPhoto:Rating>50</MicrosoftPhoto:Rating>
+ </rdf:Description>
+
+ <rdf:Description rdf:about=''
+  xmlns:aux='http://ns.adobe.com/exif/1.0/aux/'>
+  <aux:ApproximateFocusDistance>213/100</aux:ApproximateFocusDistance>
+  <aux:Firmware>1.0.2</aux:Firmware>
+  <aux:FlashCompensation>0/1</aux:FlashCompensation>
+  <aux:ImageNumber>0</aux:ImageNumber>
+  <aux:Lens>EF-S15-85mm f/3.5-5.6 IS USM</aux:Lens>
+  <aux:LensID>488</aux:LensID>
+ </rdf:Description>
+
+ <rdf:Description rdf:about=''
+  xmlns:crs='http://ns.adobe.com/camera-raw-settings/1.0/'>
+  <crs:AlreadyApplied>True</crs:AlreadyApplied>
+  <crs:AutoLateralCA>0</crs:AutoLateralCA>
+  <crs:AutoWhiteVersion>134348800</crs:AutoWhiteVersion>
+  <crs:Blacks2012>-10</crs:Blacks2012>
+  <crs:BlueHue>0</crs:BlueHue>
+  <crs:BlueSaturation>0</crs:BlueSaturation>
+  <crs:CameraProfile>Camera Standard</crs:CameraProfile>
+  <crs:Clarity2012>+26</crs:Clarity2012>
+  <crs:ColorNoiseReduction>25</crs:ColorNoiseReduction>
+  <crs:ColorNoiseReductionDetail>50</crs:ColorNoiseReductionDetail>
+  <crs:ColorNoiseReductionSmoothness>50</crs:ColorNoiseReductionSmoothness>
+  <crs:Contrast2012>+12</crs:Contrast2012>
+  <crs:ConvertToGrayscale>False</crs:ConvertToGrayscale>
+  <crs:CropAngle>0</crs:CropAngle>
+  <crs:CropBottom>1</crs:CropBottom>
+  <crs:CropConstrainToWarp>0</crs:CropConstrainToWarp>
+  <crs:CropLeft>0</crs:CropLeft>
+  <crs:CropRight>0.768224</crs:CropRight>
+  <crs:CropTop>0.231776</crs:CropTop>
+  <crs:DefringeGreenAmount>0</crs:DefringeGreenAmount>
+  <crs:DefringeGreenHueHi>60</crs:DefringeGreenHueHi>
+  <crs:DefringeGreenHueLo>40</crs:DefringeGreenHueLo>
+  <crs:DefringePurpleAmount>0</crs:DefringePurpleAmount>
+  <crs:DefringePurpleHueHi>70</crs:DefringePurpleHueHi>
+  <crs:DefringePurpleHueLo>30</crs:DefringePurpleHueLo>
+  <crs:Dehaze>0</crs:Dehaze>
+  <crs:Exposure2012>+0.12</crs:Exposure2012>
+  <crs:GrainAmount>0</crs:GrainAmount>
+  <crs:GreenHue>0</crs:GreenHue>
+  <crs:GreenSaturation>0</crs:GreenSaturation>
+  <crs:HasCrop>True</crs:HasCrop>
+  <crs:HasSettings>True</crs:HasSettings>
+  <crs:Highlights2012>-83</crs:Highlights2012>
+  <crs:HueAdjustmentAqua>0</crs:HueAdjustmentAqua>
+  <crs:HueAdjustmentBlue>0</crs:HueAdjustmentBlue>
+  <crs:HueAdjustmentGreen>0</crs:HueAdjustmentGreen>
+  <crs:HueAdjustmentMagenta>0</crs:HueAdjustmentMagenta>
+  <crs:HueAdjustmentOrange>0</crs:HueAdjustmentOrange>
+  <crs:HueAdjustmentPurple>0</crs:HueAdjustmentPurple>
+  <crs:HueAdjustmentRed>0</crs:HueAdjustmentRed>
+  <crs:HueAdjustmentYellow>0</crs:HueAdjustmentYellow>
+  <crs:LensManualDistortionAmount>0</crs:LensManualDistortionAmount>
+  <crs:LensProfileEnable>0</crs:LensProfileEnable>
+  <crs:LensProfileSetup>LensDefaults</crs:LensProfileSetup>
+  <crs:LuminanceAdjustmentAqua>0</crs:LuminanceAdjustmentAqua>
+  <crs:LuminanceAdjustmentBlue>0</crs:LuminanceAdjustmentBlue>
+  <crs:LuminanceAdjustmentGreen>0</crs:LuminanceAdjustmentGreen>
+  <crs:LuminanceAdjustmentMagenta>0</crs:LuminanceAdjustmentMagenta>
+  <crs:LuminanceAdjustmentOrange>0</crs:LuminanceAdjustmentOrange>
+  <crs:LuminanceAdjustmentPurple>0</crs:LuminanceAdjustmentPurple>
+  <crs:LuminanceAdjustmentRed>0</crs:LuminanceAdjustmentRed>
+  <crs:LuminanceAdjustmentYellow>0</crs:LuminanceAdjustmentYellow>
+  <crs:LuminanceNoiseReductionContrast>0</crs:LuminanceNoiseReductionContrast>
+  <crs:LuminanceNoiseReductionDetail>50</crs:LuminanceNoiseReductionDetail>
+  <crs:LuminanceSmoothing>21</crs:LuminanceSmoothing>
+  <crs:ParametricDarks>0</crs:ParametricDarks>
+  <crs:ParametricHighlightSplit>75</crs:ParametricHighlightSplit>
+  <crs:ParametricHighlights>0</crs:ParametricHighlights>
+  <crs:ParametricLights>0</crs:ParametricLights>
+  <crs:ParametricMidtoneSplit>50</crs:ParametricMidtoneSplit>
+  <crs:ParametricShadowSplit>25</crs:ParametricShadowSplit>
+  <crs:ParametricShadows>0</crs:ParametricShadows>
+  <crs:PerspectiveAspect>0</crs:PerspectiveAspect>
+  <crs:PerspectiveHorizontal>0</crs:PerspectiveHorizontal>
+  <crs:PerspectiveRotate>0.0</crs:PerspectiveRotate>
+  <crs:PerspectiveScale>100</crs:PerspectiveScale>
+  <crs:PerspectiveUpright>0</crs:PerspectiveUpright>
+  <crs:PerspectiveVertical>0</crs:PerspectiveVertical>
+  <crs:PostCropVignetteAmount>0</crs:PostCropVignetteAmount>
+  <crs:ProcessVersion>6.7</crs:ProcessVersion>
+  <crs:RawFileName>IMG_5910.jpg</crs:RawFileName>
+  <crs:RedHue>0</crs:RedHue>
+  <crs:RedSaturation>0</crs:RedSaturation>
+  <crs:SaturationAdjustmentAqua>0</crs:SaturationAdjustmentAqua>
+  <crs:SaturationAdjustmentBlue>0</crs:SaturationAdjustmentBlue>
+  <crs:SaturationAdjustmentGreen>-20</crs:SaturationAdjustmentGreen>
+  <crs:SaturationAdjustmentMagenta>0</crs:SaturationAdjustmentMagenta>
+  <crs:SaturationAdjustmentOrange>+27</crs:SaturationAdjustmentOrange>
+  <crs:SaturationAdjustmentPurple>0</crs:SaturationAdjustmentPurple>
+  <crs:SaturationAdjustmentRed>+24</crs:SaturationAdjustmentRed>
+  <crs:SaturationAdjustmentYellow>+27</crs:SaturationAdjustmentYellow>
+  <crs:ShadowTint>0</crs:ShadowTint>
+  <crs:Shadows2012>+64</crs:Shadows2012>
+  <crs:SharpenDetail>25</crs:SharpenDetail>
+  <crs:SharpenEdgeMasking>0</crs:SharpenEdgeMasking>
+  <crs:SharpenRadius>+1.0</crs:SharpenRadius>
+  <crs:SplitToningBalance>0</crs:SplitToningBalance>
+  <crs:SplitToningHighlightHue>0</crs:SplitToningHighlightHue>
+  <crs:SplitToningHighlightSaturation>0</crs:SplitToningHighlightSaturation>
+  <crs:SplitToningShadowHue>0</crs:SplitToningShadowHue>
+  <crs:SplitToningShadowSaturation>0</crs:SplitToningShadowSaturation>
+  <crs:Temperature>4300</crs:Temperature>
+  <crs:Tint>+20</crs:Tint>
+  <crs:ToneCurve>
+   <rdf:Seq>
+    <rdf:li>0, 0</rdf:li>
+    <rdf:li>255, 255</rdf:li>
+   </rdf:Seq>
+  </crs:ToneCurve>
+  <crs:ToneCurveBlue>
+   <rdf:Seq>
+    <rdf:li>0, 0</rdf:li>
+    <rdf:li>255, 255</rdf:li>
+   </rdf:Seq>
+  </crs:ToneCurveBlue>
+  <crs:ToneCurveGreen>
+   <rdf:Seq>
+    <rdf:li>0, 0</rdf:li>
+    <rdf:li>255, 255</rdf:li>
+   </rdf:Seq>
+  </crs:ToneCurveGreen>
+  <crs:ToneCurveName>Linear</crs:ToneCurveName>
+  <crs:ToneCurveName2012>Linear</crs:ToneCurveName2012>
+  <crs:ToneCurvePV2012>
+   <rdf:Seq>
+    <rdf:li>0, 0</rdf:li>
+    <rdf:li>255, 255</rdf:li>
+   </rdf:Seq>
+  </crs:ToneCurvePV2012>
+  <crs:ToneCurvePV2012Blue>
+   <rdf:Seq>
+    <rdf:li>0, 0</rdf:li>
+    <rdf:li>255, 255</rdf:li>
+   </rdf:Seq>
+  </crs:ToneCurvePV2012Blue>
+  <crs:ToneCurvePV2012Green>
+   <rdf:Seq>
+    <rdf:li>0, 0</rdf:li>
+    <rdf:li>255, 255</rdf:li>
+   </rdf:Seq>
+  </crs:ToneCurvePV2012Green>
+  <crs:ToneCurvePV2012Red>
+   <rdf:Seq>
+    <rdf:li>0, 0</rdf:li>
+    <rdf:li>255, 255</rdf:li>
+   </rdf:Seq>
+  </crs:ToneCurvePV2012Red>
+  <crs:ToneCurveRed>
+   <rdf:Seq>
+    <rdf:li>0, 0</rdf:li>
+    <rdf:li>255, 255</rdf:li>
+   </rdf:Seq>
+  </crs:ToneCurveRed>
+  <crs:ToneMapStrength>0</crs:ToneMapStrength>
+  <crs:Version>9.1</crs:Version>
+  <crs:Vibrance>+19</crs:Vibrance>
+  <crs:VignetteAmount>0</crs:VignetteAmount>
+  <crs:Whites2012>+1</crs:Whites2012>
+ </rdf:Description>
+
+ <rdf:Description rdf:about=''
+  xmlns:dc='http://purl.org/dc/elements/1.1/'>
+  <dc:creator>
+   <rdf:Seq>
+    <rdf:li>Patrik</rdf:li>
+   </rdf:Seq>
+  </dc:creator>
+  <dc:description>
+   <rdf:Alt>
+    <rdf:li xml:lang='x-default'>Squirrel at berkely</rdf:li>
+   </rdf:Alt>
+  </dc:description>
+  <dc:format>image/jpeg</dc:format>
+  <dc:subject>
+   <rdf:Bag>
+    <rdf:li>Alvin the Squirrel</rdf:li>
+    <rdf:li>Berkley</rdf:li>
+    <rdf:li>USA</rdf:li>
+    <rdf:li>test</rdf:li>
+   </rdf:Bag>
+  </dc:subject>
+  <dc:title>
+   <rdf:Alt>
+    <rdf:li xml:lang='x-default'>Squirrel at berkely</rdf:li>
+   </rdf:Alt>
+  </dc:title>
+ </rdf:Description>
+
+ <rdf:Description rdf:about=''
+  xmlns:exif='http://ns.adobe.com/exif/1.0/'>
+  <exif:ApertureValue>40761/8200</exif:ApertureValue>
+  <exif:ColorSpace>1</exif:ColorSpace>
+  <exif:CustomRendered>0</exif:CustomRendered>
+  <exif:DateTimeOriginal>2015-06-12T10:29:26</exif:DateTimeOriginal>
+  <exif:ExifVersion>0230</exif:ExifVersion>
+  <exif:ExposureBiasValue>0/1</exif:ExposureBiasValue>
+  <exif:ExposureMode>0</exif:ExposureMode>
+  <exif:ExposureProgram>6</exif:ExposureProgram>
+  <exif:ExposureTime>1/800</exif:ExposureTime>
+  <exif:FNumber>28/5</exif:FNumber>
+  <exif:Flash rdf:parseType='Resource'>
+   <exif:Fired>False</exif:Fired>
+   <exif:Function>False</exif:Function>
+   <exif:Mode>2</exif:Mode>
+   <exif:RedEyeMode>False</exif:RedEyeMode>
+   <exif:Return>0</exif:Return>
+  </exif:Flash>
+  <exif:FocalLength>85/1</exif:FocalLength>
+  <exif:FocalPlaneResolutionUnit>2</exif:FocalPlaneResolutionUnit>
+  <exif:FocalPlaneXResolution>1036800/181</exif:FocalPlaneXResolution>
+  <exif:FocalPlaneYResolution>691200/119</exif:FocalPlaneYResolution>
+  <exif:GPSAltitude>90/1</exif:GPSAltitude>
+  <exif:GPSLatitude>37,52.2656N</exif:GPSLatitude>
+  <exif:GPSLongitude>122,15.4068W</exif:GPSLongitude>
+  <exif:GPSVersionID>2.2.0.0</exif:GPSVersionID>
+  <exif:ISOSpeedRatings>
+   <rdf:Seq>
+    <rdf:li>3200</rdf:li>
+   </rdf:Seq>
+  </exif:ISOSpeedRatings>
+  <exif:MaxApertureValue>18325/3649</exif:MaxApertureValue>
+  <exif:MeteringMode>5</exif:MeteringMode>
+  <exif:Saturation>2</exif:Saturation>
+  <exif:SceneCaptureType>0</exif:SceneCaptureType>
+  <exif:Sharpness>2</exif:Sharpness>
+  <exif:ShutterSpeedValue>19307/2002</exif:ShutterSpeedValue>
+  <exif:WhiteBalance>0</exif:WhiteBalance>
+ </rdf:Description>
+
+ <rdf:Description rdf:about=''
+  xmlns:exifEX='http://cipa.jp/exif/1.0/'>
+  <exifEX:BodySerialNumber>123063022888</exifEX:BodySerialNumber>
+  <exifEX:LensModel>EF-S15-85mm f/3.5-5.6 IS USM</exifEX:LensModel>
+  <exifEX:LensSerialNumber>0000129324</exifEX:LensSerialNumber>
+  <exifEX:LensSpecification>
+   <rdf:Seq>
+    <rdf:li>15/1</rdf:li>
+    <rdf:li>85/1</rdf:li>
+    <rdf:li>0/0</rdf:li>
+    <rdf:li>0/0</rdf:li>
+   </rdf:Seq>
+  </exifEX:LensSpecification>
+  <exifEX:RecommendedExposureIndex>3200</exifEX:RecommendedExposureIndex>
+  <exifEX:SensitivityType>2</exifEX:SensitivityType>
+ </rdf:Description>
+
+ <rdf:Description rdf:about=''
+  xmlns:lr='http://ns.adobe.com/lightroom/1.0/'>
+  <lr:hierarchicalSubject>
+   <rdf:Bag>
+    <rdf:li>Alvin the Squirrel</rdf:li>
+    <rdf:li>Berkley</rdf:li>
+    <rdf:li>USA</rdf:li>
+   </rdf:Bag>
+  </lr:hierarchicalSubject>
+  <lr:weightedFlatSubject>
+   <rdf:Bag>
+    <rdf:li>Alvin the Squirrel</rdf:li>
+    <rdf:li>Berkley</rdf:li>
+    <rdf:li>USA</rdf:li>
+   </rdf:Bag>
+  </lr:weightedFlatSubject>
+ </rdf:Description>
+
+ <rdf:Description rdf:about=''
+  xmlns:mwg-rs='http://www.metadataworkinggroup.com/schemas/regions/'
+  xmlns:stArea='http://ns.adobe.com/xmp/sType/Area#'
+  xmlns:stDim='http://ns.adobe.com/xap/1.0/sType/Dimensions#'>
+  <mwg-rs:Regions rdf:parseType='Resource'>
+   <mwg-rs:AppliedToDimensions rdf:parseType='Resource'>
+    <stDim:h>930</stDim:h>
+    <stDim:unit>pixel</stDim:unit>
+    <stDim:w>1394</stDim:w>
+   </mwg-rs:AppliedToDimensions>
+   <mwg-rs:RegionList>
+    <rdf:Bag>
+     <rdf:li rdf:parseType='Resource'>
+      <mwg-rs:Area rdf:parseType='Resource'>
+       <stArea:h>0.28108</stArea:h>
+       <stArea:w>0.21731</stArea:w>
+       <stArea:x>0.57214</stArea:x>
+       <stArea:y>0.42297</stArea:y>
+      </mwg-rs:Area>
+      <mwg-rs:Name>Alvin the Squirrel</mwg-rs:Name>
+      <mwg-rs:Rotation>0.00000</mwg-rs:Rotation>
+      <mwg-rs:Type>Face</mwg-rs:Type>
+     </rdf:li>
+    </rdf:Bag>
+   </mwg-rs:RegionList>
+  </mwg-rs:Regions>
+ </rdf:Description>
+
+ <rdf:Description rdf:about=''
+  xmlns:pdf='http://ns.adobe.com/pdf/1.3/'>
+  <pdf:Keywords>Alvin the Squirrel, Berkley, USA</pdf:Keywords>
+ </rdf:Description>
+
+ <rdf:Description rdf:about=''
+  xmlns:photoshop='http://ns.adobe.com/photoshop/1.0/'>
+  <photoshop:City>Berkeley</photoshop:City>
+  <photoshop:Country>United States</photoshop:Country>
+  <photoshop:DateCreated>2015-06-12</photoshop:DateCreated>
+  <photoshop:State>California</photoshop:State>
+ </rdf:Description>
+
+ <rdf:Description rdf:about=''
+  xmlns:tiff='http://ns.adobe.com/tiff/1.0/'>
+  <tiff:Artist>Patrik</tiff:Artist>
+  <tiff:BitsPerSample>
+   <rdf:Seq>
+    <rdf:li>8</rdf:li>
+   </rdf:Seq>
+  </tiff:BitsPerSample>
+  <tiff:Compression>6</tiff:Compression>
+  <tiff:ImageDescription>
+   <rdf:Alt>
+    <rdf:li xml:lang='x-default'>Squirrel at berkely</rdf:li>
+   </rdf:Alt>
+  </tiff:ImageDescription>
+  <tiff:ImageLength>930</tiff:ImageLength>
+  <tiff:ImageWidth>1394</tiff:ImageWidth>
+  <tiff:Make>Canon</tiff:Make>
+  <tiff:Model>Canon EOS 600D</tiff:Model>
+  <tiff:Orientation>1</tiff:Orientation>
+  <tiff:ResolutionUnit>3</tiff:ResolutionUnit>
+  <tiff:Software>Adobe Photoshop Lightroom 6.1 (Windows)</tiff:Software>
+  <tiff:XResolution>94/1</tiff:XResolution>
+  <tiff:YCbCrSubSampling>
+   <rdf:Seq>
+    <rdf:li>2</rdf:li>
+    <rdf:li>2</rdf:li>
+   </rdf:Seq>
+  </tiff:YCbCrSubSampling>
+  <tiff:YResolution>94/1</tiff:YResolution>
+ </rdf:Description>
+
+ <rdf:Description rdf:about=''
+  xmlns:xmp='http://ns.adobe.com/xap/1.0/'>
+  <xmp:CreateDate>2015-06-11T10:29:26</xmp:CreateDate>
+  <xmp:CreatorTool>Adobe Photoshop Lightroom 6.1 (Windows)</xmp:CreatorTool>
+  <xmp:MetadataDate>2023-09-02T16:18:48+02:00</xmp:MetadataDate>
+  <xmp:ModifyDate>2015-07-24T22:45:50</xmp:ModifyDate>
+  <xmp:Rating>3</xmp:Rating>
+ </rdf:Description>
+
+ <rdf:Description rdf:about=''
+  xmlns:stEvt='http://ns.adobe.com/xap/1.0/sType/ResourceEvent#'
+  xmlns:stRef='http://ns.adobe.com/xap/1.0/sType/ResourceRef#'
+  xmlns:xmpMM='http://ns.adobe.com/xap/1.0/mm/'>
+  <xmpMM:DerivedFrom rdf:parseType='Resource'>
+   <stRef:documentID>B6C3AD6C2A4882C8DBC687A5511B328D</stRef:documentID>
+   <stRef:originalDocumentID>B6C3AD6C2A4882C8DBC687A5511B328D</stRef:originalDocumentID>
+  </xmpMM:DerivedFrom>
+  <xmpMM:DocumentID>xmp.did:bbbfe6e4-c352-5441-a4c0-d1a95da2ac63</xmpMM:DocumentID>
+  <xmpMM:History>
+   <rdf:Seq>
+    <rdf:li rdf:parseType='Resource'>
+     <stEvt:action>derived</stEvt:action>
+     <stEvt:parameters>converted from image/x-canon-cr2 to image/jpeg, saved to new location</stEvt:parameters>
+    </rdf:li>
+    <rdf:li rdf:parseType='Resource'>
+     <stEvt:action>saved</stEvt:action>
+     <stEvt:changed>/</stEvt:changed>
+     <stEvt:instanceID>xmp.iid:bbbfe6e4-c352-5441-a4c0-d1a95da2ac63</stEvt:instanceID>
+     <stEvt:softwareAgent>Adobe Photoshop Lightroom 6.1 (Windows)</stEvt:softwareAgent>
+     <stEvt:when>2015-07-24T22:45:50+02:00</stEvt:when>
+    </rdf:li>
+    <rdf:li rdf:parseType='Resource'>
+     <stEvt:action>saved</stEvt:action>
+     <stEvt:changed>/metadata</stEvt:changed>
+     <stEvt:instanceID>xmp.iid:2ae29592-26ec-d344-ac38-bdbca6a40891</stEvt:instanceID>
+     <stEvt:softwareAgent>Adobe Photoshop Lightroom 6.1 (Windows)</stEvt:softwareAgent>
+     <stEvt:when>2015-07-24T22:45:51+02:00</stEvt:when>
+    </rdf:li>
+    <rdf:li rdf:parseType='Resource'>
+     <stEvt:action>saved</stEvt:action>
+     <stEvt:changed>/metadata</stEvt:changed>
+     <stEvt:instanceID>xmp.iid:bcb273dc-155b-d546-80b8-63148cc30f8b</stEvt:instanceID>
+     <stEvt:softwareAgent>Adobe Photoshop Lightroom Classic 11.2 (Windows)</stEvt:softwareAgent>
+     <stEvt:when>2023-09-02T16:18:48+02:00</stEvt:when>
+    </rdf:li>
+   </rdf:Seq>
+  </xmpMM:History>
+  <xmpMM:InstanceID>xmp.iid:bcb273dc-155b-d546-80b8-63148cc30f8b</xmpMM:InstanceID>
+  <xmpMM:OriginalDocumentID>B6C3AD6C2A4882C8DBC687A5511B328D</xmpMM:OriginalDocumentID>
+  <xmpMM:PreservedFileName>IMG_5910.jpg</xmpMM:PreservedFileName>
+ </rdf:Description>
+</rdf:RDF>
+</x:xmpmeta>
+<?xpacket end='w'?>

--- a/demo/images/bunny.mp4.xmp
+++ b/demo/images/bunny.mp4.xmp
@@ -1,0 +1,118 @@
+<?xpacket begin='﻿' id='W5M0MpCehiHzreSzNTczkc9d'?>
+<x:xmpmeta xmlns:x='adobe:ns:meta/' x:xmptk='Image::ExifTool 12.69'>
+<rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
+
+ <rdf:Description rdf:about=''
+  xmlns:Iptc4xmpExt='http://iptc.org/std/Iptc4xmpExt/2008-02-29/'>
+  <Iptc4xmpExt:audioBitsPerSample>16</Iptc4xmpExt:audioBitsPerSample>
+ </rdf:Description>
+
+ <rdf:Description rdf:about=''
+  xmlns:LImage='http://ns.leiainc.com/photos/1.0/image/'>
+  <LImage:MinorVersion>0.0.0</LImage:MinorVersion>
+ </rdf:Description>
+
+ <rdf:Description rdf:about=''
+  xmlns:dc='http://purl.org/dc/elements/1.1/'>
+  <dc:format>H.264</dc:format>
+  <dc:subject>
+   <rdf:Bag>
+    <rdf:li>rabbit</rdf:li>
+    <rdf:li>test</rdf:li>
+   </rdf:Bag>
+  </dc:subject>  
+ </rdf:Description>
+
+ <rdf:Description rdf:about=''
+  xmlns:tiff='http://ns.adobe.com/tiff/1.0/'>
+  <tiff:ImageLength>480</tiff:ImageLength>
+  <tiff:ImageWidth>852</tiff:ImageWidth>
+  <tiff:XResolution>72/1</tiff:XResolution>
+  <tiff:YResolution>72/1</tiff:YResolution>
+ </rdf:Description>
+
+ <rdf:Description rdf:about=''
+  xmlns:xmp='http://ns.adobe.com/xap/1.0/'>
+  <xmp:CreateDate>2018-11-17T20:27:31+01:00</xmp:CreateDate>
+  <xmp:MetadataDate>2018-11-17T20:27:31+01:00</xmp:MetadataDate>
+  <xmp:ModifyDate>2018-11-17T20:27:31+01:00</xmp:ModifyDate>
+ </rdf:Description>
+
+ <rdf:Description rdf:about=''
+  xmlns:stDim='http://ns.adobe.com/xap/1.0/sType/Dimensions#'
+  xmlns:xmpDM='http://ns.adobe.com/xmp/1.0/DynamicMedia/'>
+  <xmpDM:altTimecode rdf:parseType='Resource'>
+   <xmpDM:timeFormat>25Timecode</xmpDM:timeFormat>
+   <xmpDM:timeValue>00:00:00:00</xmpDM:timeValue>
+  </xmpDM:altTimecode>
+  <xmpDM:audioChannelType>Stereo</xmpDM:audioChannelType>
+  <xmpDM:audioSampleRate>48000</xmpDM:audioSampleRate>
+  <xmpDM:audioSampleType>16Int</xmpDM:audioSampleType>
+  <xmpDM:duration rdf:parseType='Resource'>
+   <xmpDM:scale>1/90000</xmpDM:scale>
+   <xmpDM:value>2928000</xmpDM:value>
+  </xmpDM:duration>
+  <xmpDM:startTimeSampleSize>1</xmpDM:startTimeSampleSize>
+  <xmpDM:startTimeScale>25</xmpDM:startTimeScale>
+  <xmpDM:startTimecode rdf:parseType='Resource'>
+   <xmpDM:timeFormat>25Timecode</xmpDM:timeFormat>
+   <xmpDM:timeValue>00:00:00:00</xmpDM:timeValue>
+  </xmpDM:startTimecode>
+  <xmpDM:videoFieldOrder>Progressive</xmpDM:videoFieldOrder>
+  <xmpDM:videoFrameRate>25.000000</xmpDM:videoFrameRate>
+  <xmpDM:videoFrameSize rdf:parseType='Resource'>
+   <stDim:h>480</stDim:h>
+   <stDim:unit>pixel</stDim:unit>
+   <stDim:w>852</stDim:w>
+  </xmpDM:videoFrameSize>
+  <xmpDM:videoPixelAspectRatio>1/1</xmpDM:videoPixelAspectRatio>
+ </rdf:Description>
+
+ <rdf:Description rdf:about=''
+  xmlns:stEvt='http://ns.adobe.com/xap/1.0/sType/ResourceEvent#'
+  xmlns:stRef='http://ns.adobe.com/xap/1.0/sType/ResourceRef#'
+  xmlns:xmpMM='http://ns.adobe.com/xap/1.0/mm/'>
+  <xmpMM:DerivedFrom rdf:parseType='Resource'>
+   <stRef:documentID>d47681ee-e57e-2256-f455-43c40000004b</stRef:documentID>
+   <stRef:instanceID>2a5a623f-09cc-ea32-5014-869400000078</stRef:instanceID>
+   <stRef:originalDocumentID>xmp.did:5af8e6dd-2af0-e94e-8f3c-767794b3efa1</stRef:originalDocumentID>
+  </xmpMM:DerivedFrom>
+  <xmpMM:DocumentID>b2c5763f-bfb9-7ee1-6893-05220000004b</xmpMM:DocumentID>
+  <xmpMM:History>
+   <rdf:Seq>
+    <rdf:li rdf:parseType='Resource'>
+     <stEvt:action>saved</stEvt:action>
+     <stEvt:changed>/</stEvt:changed>
+     <stEvt:instanceID>63c4c09c-9648-ee43-720e-644600000078</stEvt:instanceID>
+     <stEvt:softwareAgent>Adobe Adobe Media Encoder CC 2017.1 (Windows)</stEvt:softwareAgent>
+     <stEvt:when>2018-11-17T20:27:31+01:00</stEvt:when>
+    </rdf:li>
+    <rdf:li rdf:parseType='Resource'>
+     <stEvt:action>saved</stEvt:action>
+     <stEvt:changed>/</stEvt:changed>
+     <stEvt:instanceID>2a5a623f-09cc-ea32-5014-869400000078</stEvt:instanceID>
+     <stEvt:softwareAgent>Adobe Adobe Media Encoder CC 2017.1 (Windows)</stEvt:softwareAgent>
+     <stEvt:when>2018-11-17T20:26:54+01:00</stEvt:when>
+    </rdf:li>
+    <rdf:li rdf:parseType='Resource'>
+     <stEvt:action>saved</stEvt:action>
+     <stEvt:changed>/</stEvt:changed>
+     <stEvt:instanceID>xmp.iid:6e43712c-17f5-cc4c-b90d-766dca2590dc</stEvt:instanceID>
+     <stEvt:softwareAgent>Adobe Adobe Media Encoder CC 2017.1 (Windows)</stEvt:softwareAgent>
+     <stEvt:when>2018-11-17T20:27:31+01:00</stEvt:when>
+    </rdf:li>
+    <rdf:li rdf:parseType='Resource'>
+     <stEvt:action>saved</stEvt:action>
+     <stEvt:changed>/metadata</stEvt:changed>
+     <stEvt:instanceID>xmp.iid:4d4376d3-c650-354b-b4eb-0fc2d21bcaa4</stEvt:instanceID>
+     <stEvt:softwareAgent>Adobe Adobe Media Encoder CC 2017.1 (Windows)</stEvt:softwareAgent>
+     <stEvt:when>2018-11-17T20:27:31+01:00</stEvt:when>
+    </rdf:li>
+   </rdf:Seq>
+  </xmpMM:History>
+  <xmpMM:InstanceID>xmp.iid:4d4376d3-c650-354b-b4eb-0fc2d21bcaa4</xmpMM:InstanceID>
+  <xmpMM:OriginalDocumentID>xmp.did:1aa2d671-bf82-2043-9053-ec864079866c</xmpMM:OriginalDocumentID>
+ </rdf:Description>
+</rdf:RDF>
+</x:xmpmeta>
+<?xpacket end='w'?>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pigallery2",
-  "version": "2.0.0-rc",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pigallery2",
-      "version": "2.0.0-rc",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "archiver": "5.3.1",
@@ -16,6 +16,7 @@
         "cookie-session": "2.0.0",
         "csurf": "1.11.0",
         "ejs": "3.1.8",
+        "exifr": "7.1.3",
         "exifreader": "4.10.0",
         "express": "4.18.2",
         "express-unless": "2.1.3",
@@ -10845,6 +10846,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/exifr": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/exifr/-/exifr-7.1.3.tgz",
+      "integrity": "sha512-g/aje2noHivrRSLbAUtBPWFbxKdKhgj/xr1vATDdUXPOFYJlQ62Ft0oy+72V6XLIpDJfHs6gXLbBLAolqOXYRw=="
     },
     "node_modules/exifreader": {
       "version": "4.10.0",
@@ -32248,6 +32254,11 @@
       "requires": {
         "pify": "^2.2.0"
       }
+    },
+    "exifr": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/exifr/-/exifr-7.1.3.tgz",
+      "integrity": "sha512-g/aje2noHivrRSLbAUtBPWFbxKdKhgj/xr1vATDdUXPOFYJlQ62Ft0oy+72V6XLIpDJfHs6gXLbBLAolqOXYRw=="
     },
     "exifreader": {
       "version": "4.10.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "cookie-session": "2.0.0",
     "csurf": "1.11.0",
     "ejs": "3.1.8",
+    "exifr": "7.1.3",
     "exifreader": "4.10.0",
     "express": "4.18.2",
     "express-unless": "2.1.3",

--- a/src/backend/model/fileaccess/MetadataLoader.ts
+++ b/src/backend/model/fileaccess/MetadataLoader.ts
@@ -32,7 +32,7 @@ export class MetadataLoader {
         fileSize: 0,
         fps: 0,
       };
-      
+
       try {
         // search for sidecar and merge metadata
         const fullPathWithoutExt = path.parse(fullPath).name;
@@ -176,6 +176,28 @@ export class MetadataLoader {
               const stat = fs.statSync(fullPath);
               metadata.fileSize = stat.size;
               metadata.creationDate = stat.mtime.getTime();
+            } catch (err) {
+              // ignoring errors
+            }
+
+            try {
+              // search for sidecar and merge metadata
+              const fullPathWithoutExt = path.parse(fullPath).name;
+              const sidecarPaths = [
+                fullPath + '.xmp',
+                fullPath + '.XMP',
+                fullPathWithoutExt + '.xmp',
+                fullPathWithoutExt + '.XMP',
+              ];
+      
+              for (const sidecarPath of sidecarPaths) {
+                if (fs.existsSync(sidecarPath)) {
+                  const sidecarData = exifr.sidecar(sidecarPath);
+                  sidecarData.then((response) => {
+                    metadata.keywords = [(response as any).dc.subject].flat();
+                  });
+                }
+              }
             } catch (err) {
               // ignoring errors
             }

--- a/src/common/entities/ConentWrapper.ts
+++ b/src/common/entities/ConentWrapper.ts
@@ -241,7 +241,6 @@ export class ContentWrapper {
         delete (m as PhotoDTO).metadata.rating;
         delete (m as PhotoDTO).metadata.caption;
         delete (m as PhotoDTO).metadata.cameraData;
-        delete (m as PhotoDTO).metadata.keywords;
         delete (m as PhotoDTO).metadata.faces;
         delete (m as PhotoDTO).metadata.positionData;
         ContentWrapper.mapify(cw, m, isSearchResult);

--- a/src/common/entities/VideoDTO.ts
+++ b/src/common/entities/VideoDTO.ts
@@ -15,4 +15,5 @@ export interface VideoMetadata extends MediaMetadata {
   duration: number; // in milliseconds
   fileSize: number;
   fps: number;
+  keywords?: string[];
 }


### PR DESCRIPTION
This pull request adds xmp sidecar support using exifr in order to gain access to keywords metadata for video files. It can be extended to collect additional data for videos or photos and is a first step towards reducing the number of exif readers per #277 .

This is a first step towards #156 
Exifr was chosen per #277 
Work accelerated by reviewing exiftool code from @mcdamo on #294

Known limitation of this pull request:
-Keywords for videos do not show up in the info panel but tagged videos are returned when you search for the keyword.

It's unclear to me why the tags do not show up in the info panel on the videos. **If you search for keyword:test or keyword:rabbit you will get back the bunny.mp4 video**, suggesting they are correctly recorded in the database. 

I attempted modification of frontend files to identify video vs photo and load metadata separately for them on the info panel believing that to be the issue, but the problem was deeper. When logged to console in the browser, metadata.keywords was showing as undefined. Given this, it's not clear my modifications to the frontend were even necessary, and I have not included them. I would be happy to look at it further with some pointers on why metadata.keywords is returning undefined on the frontend for videos despite them returning in keyword search results.