### PR TITLE
add description for album reset

### DIFF
--- a/src/common/config/public/ClientConfig.ts
+++ b/src/common/config/public/ClientConfig.ts
@@ -1457,6 +1457,7 @@ export class ClientConfig {
         hideProgress: true
       }]
     } as TAGS,
+    description: $localize`An album reset deletes all albums (all saved searches).`
   })
   Album: ClientAlbumConfig = new ClientAlbumConfig();
 


### PR DESCRIPTION
I didn't know that an `album reset` would delete all saved searches (albums), so I lost all my albums with a single click.
To prevent other PiGallery2 users from that mistake, I just added a description to `album reset`.