### PR TITLE
Added ratings to xmp sidecar support

### DIFF
--- a/demo/images/IMG_5910.jpg.xmp
+++ b/demo/images/IMG_5910.jpg.xmp
@@ -356,7 +356,7 @@
   <xmp:CreatorTool>Adobe Photoshop Lightroom 6.1 (Windows)</xmp:CreatorTool>
   <xmp:MetadataDate>2023-09-02T16:18:48+02:00</xmp:MetadataDate>
   <xmp:ModifyDate>2015-07-24T22:45:50</xmp:ModifyDate>
-  <xmp:Rating>3</xmp:Rating>
+  <xmp:Rating>4</xmp:Rating>
  </rdf:Description>
 
  <rdf:Description rdf:about=''

--- a/demo/images/bunny.mp4.xmp
+++ b/demo/images/bunny.mp4.xmp
@@ -36,6 +36,7 @@
   <xmp:CreateDate>2018-11-17T20:27:31+01:00</xmp:CreateDate>
   <xmp:MetadataDate>2018-11-17T20:27:31+01:00</xmp:MetadataDate>
   <xmp:ModifyDate>2018-11-17T20:27:31+01:00</xmp:ModifyDate>
+  <xmp:Rating>4</xmp:Rating>
  </rdf:Description>
 
  <rdf:Description rdf:about=''

--- a/src/backend/model/fileaccess/MetadataLoader.ts
+++ b/src/backend/model/fileaccess/MetadataLoader.ts
@@ -51,6 +51,7 @@ export class MetadataLoader {
             const sidecarData = exifr.sidecar(sidecarPath);
             sidecarData.then((response) => {
               metadata.keywords = [(response as any).dc.subject].flat();
+              metadata.rating = (response as any).xmp.Rating;
             });
           }
         }
@@ -199,6 +200,7 @@ export class MetadataLoader {
                   const sidecarData = exifr.sidecar(sidecarPath);
                   sidecarData.then((response) => {
                     metadata.keywords = [(response as any).dc.subject].flat();
+                    metadata.rating = (response as any).xmp.Rating;
                   });
                 }
               }

--- a/src/common/entities/ConentWrapper.ts
+++ b/src/common/entities/ConentWrapper.ts
@@ -238,7 +238,6 @@ export class ContentWrapper {
         }
         ContentWrapper.mapify(cw, m, isSearchResult);
       } else if (MediaDTOUtils.isVideo(m)) {
-        delete (m as PhotoDTO).metadata.rating;
         delete (m as PhotoDTO).metadata.caption;
         delete (m as PhotoDTO).metadata.cameraData;
         delete (m as PhotoDTO).metadata.faces;

--- a/src/common/entities/MediaDTO.ts
+++ b/src/common/entities/MediaDTO.ts
@@ -11,10 +11,14 @@ export interface MediaDTO extends FileDTO {
   missingThumbnails?: number;
 }
 
+export type RatingTypes = 0 | 1 | 2 | 3 | 4 | 5;
+
 export interface MediaMetadata {
   size: MediaDimension;
   creationDate: number;
   fileSize: number;
+  keywords?: string[];
+  rating?: RatingTypes;
 }
 
 export interface MediaDimension {

--- a/src/common/entities/PhotoDTO.ts
+++ b/src/common/entities/PhotoDTO.ts
@@ -26,12 +26,8 @@ export interface FaceRegion {
   box?: FaceRegionBox; // some faces don t have region ass they are coming from keywords
 }
 
-export type RatingTypes = 0 | 1 | 2 | 3 | 4 | 5;
-
 export interface PhotoMetadata extends MediaMetadata {
-  rating?: RatingTypes;
   caption?: string;
-  keywords?: string[];
   cameraData?: CameraMetadata;
   positionData?: PositionMetaData;
   size: MediaDimension;

--- a/src/common/entities/PhotoDTO.ts
+++ b/src/common/entities/PhotoDTO.ts
@@ -26,8 +26,10 @@ export interface FaceRegion {
   box?: FaceRegionBox; // some faces don t have region ass they are coming from keywords
 }
 
+export type RatingTypes = 0 | 1 | 2 | 3 | 4 | 5;
+
 export interface PhotoMetadata extends MediaMetadata {
-  rating?: 0 | 1 | 2 | 3 | 4 | 5;
+  rating?: RatingTypes;
   caption?: string;
   keywords?: string[];
   cameraData?: CameraMetadata;

--- a/src/common/entities/VideoDTO.ts
+++ b/src/common/entities/VideoDTO.ts
@@ -1,6 +1,5 @@
 import {DirectoryPathDTO} from './DirectoryDTO';
 import {MediaDimension, MediaDTO, MediaMetadata} from './MediaDTO';
-import {PositionMetaData, CameraMetadata, RatingTypes} from './PhotoDTO';
 
 export interface VideoDTO extends MediaDTO {
   id: number;
@@ -16,6 +15,4 @@ export interface VideoMetadata extends MediaMetadata {
   duration: number; // in milliseconds
   fileSize: number;
   fps: number;
-  keywords?: string[];
-  rating?: RatingTypes;
 }

--- a/src/common/entities/VideoDTO.ts
+++ b/src/common/entities/VideoDTO.ts
@@ -1,5 +1,6 @@
 import {DirectoryPathDTO} from './DirectoryDTO';
 import {MediaDimension, MediaDTO, MediaMetadata} from './MediaDTO';
+import {PositionMetaData, CameraMetadata, RatingTypes} from './PhotoDTO';
 
 export interface VideoDTO extends MediaDTO {
   id: number;
@@ -16,4 +17,5 @@ export interface VideoMetadata extends MediaMetadata {
   fileSize: number;
   fps: number;
   keywords?: string[];
+  rating?: RatingTypes;
 }


### PR DESCRIPTION
Added ratings to xmp sidecar support, also added rating to bunny.mp4.xmp and a different rating in IMG_5910.jpg.xmp vs what is in the photo file to test if sidecar is functioning as primary (it is as discussed).