### PR TITLE
Disentangle filter types + library counts + selections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,13 @@
 .idea/
+.angular/
+.nyc_output/
 PiGallery2.iml
 node_modules/
 pigallery2.zip
 src/**/*.js
 src/**/*.js.map
+test/**/*.js
+test/**/*.js.map
 src/frontend/dist
 test/coverage
 test/backend/**/*.js

--- a/angular.json
+++ b/angular.json
@@ -4,7 +4,8 @@
     "schematicCollections": [
       "@angular-eslint/schematics",
       "@schematics/angular"
-    ]
+    ],
+    "analytics": false
   },
   "version": 1,
   "newProjectRoot": "projects",

--- a/src/common/Utils.ts
+++ b/src/common/Utils.ts
@@ -287,6 +287,19 @@ export class Utils {
     }
     return ret;
   }
+
+  public static collect<TItem, TRet>(iter: Iterator<TItem, TRet>) {
+    const values: TItem[] = [];
+    while (true) {
+      const nextValue = iter.next();
+  
+      if (!nextValue.done) {
+        values.push(nextValue.value as TItem);
+      } else {
+        return [values, nextValue.value as TRet] as const;
+      }
+    }
+  }
 }
 
 export class LRU<V> {

--- a/src/common/Utils.ts
+++ b/src/common/Utils.ts
@@ -290,16 +290,15 @@ export class Utils {
 
   public static collect<TItem, TRet>(iter: Iterator<TItem, TRet>) {
     const values: TItem[] = [];
-    while (true) {
-      const nextValue = iter.next();
-  
-      if (!nextValue.done) {
+    let nextValue = iter.next();
+
+    while (!nextValue.done) {
         values.push(nextValue.value as TItem);
-      } else {
-        return [values, nextValue.value as TRet] as const;
-      }
+        nextValue = iter.next();
     }
-  }
+
+    return [values, nextValue.value as TRet] as const;
+}
 }
 
 export class LRU<V> {

--- a/src/frontend/app/ui/gallery/filter/filter.gallery.component.html
+++ b/src/frontend/app/ui/gallery/filter/filter.gallery.component.html
@@ -117,7 +117,7 @@
               >{{filterService.filterState.value.filterValueCounts[filter.type]?.[option.name]}}</span>
             </li>
           </ul>
-          <div class="card-body text-center" *ngIf="options(filter).length === 0" i18n>Nothing to filter</div>
+          <div class="card-body text-center" *ngIf="filter.options.length === 0" i18n>Nothing to filter</div>
         </div>
       </div>
     </div>

--- a/src/frontend/app/ui/gallery/filter/filter.gallery.component.html
+++ b/src/frontend/app/ui/gallery/filter/filter.gallery.component.html
@@ -16,8 +16,8 @@
               <div class="d-none d-lg-block" *ngIf="freq.count < freq.max/2">{{freq.count}}</div>
             </div>
             <div class="text-bg-primary text-center  border border-primary"
-                 [class.text-bg-secondary]="freq.endDate.getTime()<ActiveFilters.dateFilter.minFilter || freq.date.getTime()>ActiveFilters.dateFilter.maxFilter "
-                 [class.border-secondary]="freq.endDate.getTime()<ActiveFilters.dateFilter.minFilter || freq.date.getTime()>ActiveFilters.dateFilter.maxFilter "
+                 [class.text-bg-secondary]="freq.endDate.getTime()<FilterState.dateFilter.minFilter || freq.date.getTime()>FilterState.dateFilter.maxFilter "
+                 [class.border-secondary]="freq.endDate.getTime()<FilterState.dateFilter.minFilter || freq.date.getTime()>FilterState.dateFilter.maxFilter "
                  [style.height.%]="(freq.count/freq.max)*100">
               <div class="d-none d-lg-block" *ngIf="freq.count >= freq.max/2">{{freq.count}}</div>
             </div>
@@ -42,10 +42,10 @@
       </div>
       <div class="col-md-1-half col-12  d-table">
         <div
-          *ngIf="ActiveFilters.dateFilter.minFilter !== NUMBER_MIN_VALUE"
-          [title]="ActiveFilters.dateFilter.minFilter | date: 'medium'"
+          *ngIf="FilterState.dateFilter.minFilter !== NUMBER_MIN_VALUE"
+          [title]="FilterState.dateFilter.minFilter | date: 'medium'"
           class="d-table-cell align-middle text-center">
-          {{ActiveFilters.dateFilter.minFilter | date: 'longDate'}}
+          {{FilterState.dateFilter.minFilter | date: 'longDate'}}
         </div>
       </div>
       <div class="date-filter-wrapper col-md-9 col-12">
@@ -64,30 +64,30 @@
 
         </div>
         <input type="range"
-               [max]="ActiveFilters.dateFilter.maxDate"
-               [min]="ActiveFilters.dateFilter.minDate"
-               [(ngModel)]="ActiveFilters.dateFilter.minFilter"
+               [max]="FilterState.dateFilter.maxDate"
+               [min]="FilterState.dateFilter.minDate"
+               [(ngModel)]="FilterState.dateFilter.minFilter"
                step="60"
                (change)="newMinDate($event); filterService.onFilterChange()"/>
         <input type="range"
                step="60"
-               [max]="ActiveFilters.dateFilter.maxDate"
-               [min]="ActiveFilters.dateFilter.minDate"
-               [(ngModel)]="ActiveFilters.dateFilter.maxFilter"
+               [max]="FilterState.dateFilter.maxDate"
+               [min]="FilterState.dateFilter.minDate"
+               [(ngModel)]="FilterState.dateFilter.maxFilter"
                (change)="newMaxDate($event); filterService.onFilterChange()"/>
 
       </div>
       <div class="col-md-1-half col-12  d-table">
         <div class="d-table-cell align-middle text-center"
-             [title]="ActiveFilters.dateFilter.maxFilter | date: 'medium'"
-             *ngIf="ActiveFilters.dateFilter.maxFilter !== NUMBER_MAX_VALUE">
-          {{ActiveFilters.dateFilter.maxFilter | date: 'longDate'}}
+             [title]="FilterState.dateFilter.maxFilter | date: 'medium'"
+             *ngIf="FilterState.dateFilter.maxFilter !== NUMBER_MAX_VALUE">
+          {{FilterState.dateFilter.maxFilter | date: 'longDate'}}
         </div>
       </div>
     </div>
     <div class="row">
       <div class="col-12 col-md-6 col-lg-3 mt-2 mt-lg-1"
-           *ngFor="let filter of ActiveFilters.selectedFilters; let i=index">
+           *ngFor="let filter of FilterState.selectedFilters; let i=index">
         <select [ngModel]="filterService.filtersMap[filter.type]"
                 (ngModelChange)="filterChangedType(i, $event.key)"
                 class="form-select" id="gallery-filter-{{i}}">

--- a/src/frontend/app/ui/gallery/filter/filter.gallery.component.html
+++ b/src/frontend/app/ui/gallery/filter/filter.gallery.component.html
@@ -88,36 +88,36 @@
     <div class="row">
       <div class="col-12 col-md-6 col-lg-3 mt-2 mt-lg-1"
            *ngFor="let filter of ActiveFilters.selectedFilters; let i=index">
-        <select [(ngModel)]="filter.filter"
+        <select [ngModel]="filterService.filtersMap[filter.type]"
                 (ngModelChange)="filterService.onFilterChange()"
                 class="form-select" id="gallery-filter-{{i}}">
-          <option *ngFor="let f of filterService.AVAILABLE_FILTERS"
+          <option *ngFor="let f of filterService.filters"
                   [ngValue]="f">{{f.name}}</option>
         </select>
         <div class="filter-column">
-          <ul class="list-group" *ngIf="filter.options.length > 0">
+          <ul class="list-group" *ngIf="options(filter).length > 0">
             <li
-              *ngFor="let option of filter.options"
-              [class.unselected]="!option.selected"
-              (click)="option.selected = !option.selected; filterService.onFilterChange()"
+              *ngFor="let option of options(filter)"
+              [class.unselected]="!filter.options.selected"
+              (click)="toggleFilterValue(filter, option.name)"
               class="filter-option list-group-item list-group-item-action d-flex justify-content-between align-items-center">
 
               <div>
                 <ng-icon name="ionFlagOutline"
                          class="pin"
-                         (click)="toggleSelectOnly(filter, option, $event)"
+                         (click)="toggleSelectOnly(filter, option.name, $event)"
                          title="Select only this"
-                         [ngClass]="isOnlySelected(filter,option) ? 'filter-only-selected' : 'filter-pin'"
+                         [ngClass]="isOnlySelected(filter, option.name) ? 'filter-only-selected' : 'filter-pin'"
                          i18n-title></ng-icon>
                 {{option.name === undefined ? unknownText : option.name}}
               </div>
               <span class="badge"
                     [class.bg-primary]="option.selected"
                     [class.bg-secondary]="!option.selected"
-              >{{option.count}}</span>
+              >{{filterService.filterState.value.filterValueCounts[filter.type]?.[option.name]}}</span>
             </li>
           </ul>
-          <div class="card-body text-center" *ngIf="filter.options.length === 0" i18n>Nothing to filter</div>
+          <div class="card-body text-center" *ngIf="options(filter).length === 0" i18n>Nothing to filter</div>
         </div>
       </div>
     </div>

--- a/src/frontend/app/ui/gallery/filter/filter.gallery.component.html
+++ b/src/frontend/app/ui/gallery/filter/filter.gallery.component.html
@@ -89,7 +89,7 @@
       <div class="col-12 col-md-6 col-lg-3 mt-2 mt-lg-1"
            *ngFor="let filter of ActiveFilters.selectedFilters; let i=index">
         <select [ngModel]="filterService.filtersMap[filter.type]"
-                (ngModelChange)="filterService.onFilterChange()"
+                (ngModelChange)="filterChangedType(i, $event.key)"
                 class="form-select" id="gallery-filter-{{i}}">
           <option *ngFor="let f of filterService.filters"
                   [ngValue]="f">{{f.name}}</option>

--- a/src/frontend/app/ui/gallery/filter/filter.gallery.component.html
+++ b/src/frontend/app/ui/gallery/filter/filter.gallery.component.html
@@ -95,11 +95,11 @@
                   [ngValue]="f">{{f.name}}</option>
         </select>
         <div class="filter-column">
-          <ul class="list-group" *ngIf="options(filter).length > 0">
+          <ul class="list-group" *ngIf="filter.options.length > 0">
             <li
-              *ngFor="let option of options(filter)"
-              [class.unselected]="!filter.options.selected"
-              (click)="toggleFilterValue(filter, option.name)"
+              *ngFor="let option of filter.options"
+              [class.unselected]="!option.selected"
+              (click)="toggleFilterValue(option)"
               class="filter-option list-group-item list-group-item-action d-flex justify-content-between align-items-center">
 
               <div>

--- a/src/frontend/app/ui/gallery/filter/filter.gallery.component.ts
+++ b/src/frontend/app/ui/gallery/filter/filter.gallery.component.ts
@@ -22,25 +22,25 @@ export class GalleryFilterComponent implements OnInit, OnDestroy {
 
   get MinDatePrc(): number {
     return (
-        ((this.ActiveFilters.dateFilter.minFilter -
-                this.ActiveFilters.dateFilter.minDate) /
-            (this.ActiveFilters.dateFilter.maxDate -
-                this.ActiveFilters.dateFilter.minDate)) *
+        ((this.FilterState.dateFilter.minFilter -
+                this.FilterState.dateFilter.minDate) /
+            (this.FilterState.dateFilter.maxDate -
+                this.FilterState.dateFilter.minDate)) *
         100
     );
   }
 
   get MaxDatePrc(): number {
     return (
-        ((this.ActiveFilters.dateFilter.maxFilter -
-                this.ActiveFilters.dateFilter.minDate) /
-            (this.ActiveFilters.dateFilter.maxDate -
-                this.ActiveFilters.dateFilter.minDate)) *
+        ((this.FilterState.dateFilter.maxFilter -
+                this.FilterState.dateFilter.minDate) /
+            (this.FilterState.dateFilter.maxDate -
+                this.FilterState.dateFilter.minDate)) *
         100
     );
   }
 
-  get ActiveFilters(): FilterState {
+  get FilterState(): FilterState {
     return this.filterService.filterState.value;
   }
 
@@ -86,16 +86,16 @@ export class GalleryFilterComponent implements OnInit, OnDestroy {
 
   newMinDate($event: Event): void {
     const diff =
-        (this.ActiveFilters.dateFilter.maxDate -
-            this.ActiveFilters.dateFilter.minDate) *
+        (this.FilterState.dateFilter.maxDate -
+            this.FilterState.dateFilter.minDate) *
         0.01;
     if (
-        this.ActiveFilters.dateFilter.minFilter >
-        this.ActiveFilters.dateFilter.maxFilter - diff
+        this.FilterState.dateFilter.minFilter >
+        this.FilterState.dateFilter.maxFilter - diff
     ) {
-      this.ActiveFilters.dateFilter.minFilter = Math.max(
-          this.ActiveFilters.dateFilter.maxFilter - diff,
-          this.ActiveFilters.dateFilter.minDate
+      this.FilterState.dateFilter.minFilter = Math.max(
+          this.FilterState.dateFilter.maxFilter - diff,
+          this.FilterState.dateFilter.minDate
       );
     }
     this.filterService.onFilterChange();
@@ -103,16 +103,16 @@ export class GalleryFilterComponent implements OnInit, OnDestroy {
 
   newMaxDate($event: Event): void {
     const diff =
-        (this.ActiveFilters.dateFilter.maxDate -
-            this.ActiveFilters.dateFilter.minDate) *
+        (this.FilterState.dateFilter.maxDate -
+            this.FilterState.dateFilter.minDate) *
         0.01;
     if (
-        this.ActiveFilters.dateFilter.maxFilter <
-        this.ActiveFilters.dateFilter.minFilter + diff
+        this.FilterState.dateFilter.maxFilter <
+        this.FilterState.dateFilter.minFilter + diff
     ) {
-      this.ActiveFilters.dateFilter.maxFilter = Math.min(
-          this.ActiveFilters.dateFilter.minFilter + diff,
-          this.ActiveFilters.dateFilter.maxDate
+      this.FilterState.dateFilter.maxFilter = Math.min(
+          this.FilterState.dateFilter.minFilter + diff,
+          this.FilterState.dateFilter.maxDate
       );
     }
     this.filterService.onFilterChange();

--- a/src/frontend/app/ui/gallery/filter/filter.gallery.component.ts
+++ b/src/frontend/app/ui/gallery/filter/filter.gallery.component.ts
@@ -47,13 +47,13 @@ export class GalleryFilterComponent implements OnInit, OnDestroy {
   filterChanged(index: number, newFilter: Filter) {
     this.filterService.filterState.value.selectedFilters[index] = {
       type: newFilter.key,
-      options: {}
+      options: []
     }
     this.filterService.onFilterChange();
   }
 
-  toggleFilterValue(filter: SelectedFilter, value: string) {
-    filter.options[value] = !filter.options[value];
+  toggleFilterValue(option: {selected: boolean}) {
+    option.selected = !option.selected
     this.filterService.onFilterChange();
   }
 
@@ -71,8 +71,8 @@ export class GalleryFilterComponent implements OnInit, OnDestroy {
   }
 
   isOnlySelected(filter: SelectedFilter, option: string): boolean {
-    const selectedEntries = Object.entries(filter.options).filter(([, selected]) => selected);
-    return selectedEntries.length === 1 && filter.options[option];
+    const selectedEntries = filter.options.filter(({selected}) => selected);
+    return selectedEntries.length === 1 && selectedEntries[0].name === option;
   }
 
   toggleSelectOnly(
@@ -81,9 +81,9 @@ export class GalleryFilterComponent implements OnInit, OnDestroy {
       event: MouseEvent
   ): void {
     if (this.isOnlySelected(filter, option)) {
-      Object.keys(filter.options).forEach((o) => filter.options[o] = true);
+      filter.options.forEach((o) => o.selected = true);
     } else {
-      Object.keys(filter.options).forEach((o) => filter.options[o] = o === option);
+      filter.options.forEach((o) => o.selected = o.name === option);
     }
     event.stopPropagation();
     this.filterService.onFilterChange();

--- a/src/frontend/app/ui/gallery/filter/filter.gallery.component.ts
+++ b/src/frontend/app/ui/gallery/filter/filter.gallery.component.ts
@@ -57,11 +57,6 @@ export class GalleryFilterComponent implements OnInit, OnDestroy {
     this.filterService.onFilterChange();
   }
 
-  options(filter: SelectedFilter) {
-    const entries = Object.entries(filter.options).map(([k, v]) => ({selected: v, name: k}))
-    return entries.sort((a, b) => this.filterService.filterState.value.filterValueCounts[filter.type][b.name] - this.filterService.filterState.value.filterValueCounts[filter.type][a.name])
-  }
-
   ngOnDestroy(): void {
     setTimeout(() => this.filterService.setShowingFilters(false));
   }

--- a/src/frontend/app/ui/gallery/filter/filter.gallery.component.ts
+++ b/src/frontend/app/ui/gallery/filter/filter.gallery.component.ts
@@ -44,9 +44,9 @@ export class GalleryFilterComponent implements OnInit, OnDestroy {
     return this.filterService.filterState.value;
   }
 
-  filterChanged(index: number, newFilter: Filter) {
+  filterChangedType(index: number, type: FilterType) {
     this.filterService.filterState.value.selectedFilters[index] = {
-      type: newFilter.key,
+      type,
       options: []
     }
     this.filterService.onFilterChange();

--- a/src/frontend/app/ui/gallery/filter/filter.service.ts
+++ b/src/frontend/app/ui/gallery/filter/filter.service.ts
@@ -1,9 +1,10 @@
-import {Injectable} from '@angular/core';
-import {BehaviorSubject, Observable} from 'rxjs';
-import {PhotoDTO} from '../../../../../common/entities/PhotoDTO';
-import {DirectoryContent} from '../contentLoader.service';
-import {debounceTime, map, switchMap} from 'rxjs/operators';
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { PhotoDTO } from '../../../../../common/entities/PhotoDTO';
+import { DirectoryContent } from '../contentLoader.service';
+import { debounceTime, map, switchMap } from 'rxjs/operators';
 import { Filters } from 'fluent-ffmpeg';
+import { debug } from 'console';
 
 export enum FilterRenderType {
   enum = 1,
@@ -14,14 +15,14 @@ const filters = {
   keywords: {
     key: 'keywords',
     name: $localize`Keywords`,
-    mapFn: (m: PhotoDTO): string[] => m.metadata.keywords,
+    mapFn: (m: PhotoDTO): string[] | undefined => m.metadata.keywords,
     renderType: FilterRenderType.enum,
     isArrayValue: true,
   },
- faces: {
-  key: 'faces',
+  faces: {
+    key: 'faces',
     name: $localize`Faces`,
-    mapFn: (m: PhotoDTO): string[] =>
+    mapFn: (m: PhotoDTO) => 
       m.metadata.faces
         ? m.metadata.faces.map((f) => f.name)
         : ['<' + $localize`no face` + '>'],
@@ -31,94 +32,89 @@ const filters = {
   faces_groups: {
     key: 'faces_groups',
     name: $localize`Faces groups`,
-    mapFn: (m: PhotoDTO): string =>
+    mapFn: (m: PhotoDTO): string[] | undefined => [
       m.metadata.faces
         ?.map((f) => f.name)
         .sort()
         .join(', '),
+    ],
     renderType: FilterRenderType.enum,
     isArrayValue: false,
   },
   caption: {
     key: 'caption',
     name: $localize`Caption`,
-    mapFn: (m: PhotoDTO): string => m.metadata.caption,
+    mapFn: (m: PhotoDTO) => [m.metadata.caption],
     renderType: FilterRenderType.enum,
   },
   rating: {
     key: 'rating',
     name: $localize`Rating`,
-    mapFn: (m: PhotoDTO): string => String(m.metadata.rating),
+    mapFn: (m: PhotoDTO) => [String(m.metadata.rating ?? '<unknown>')],
     renderType: FilterRenderType.enum,
   },
- camera: {
-  key: 'camera',
+  camera: {
+    key: 'camera',
     name: $localize`Camera`,
-    mapFn: (m: PhotoDTO): string => m.metadata.cameraData?.model,
+    mapFn: (m: PhotoDTO) => [m.metadata.cameraData?.model],
     renderType: FilterRenderType.enum,
   },
   lens: {
     key: 'lens',
     name: $localize`Lens`,
-    mapFn: (m: PhotoDTO): string => m.metadata.cameraData?.lens,
+    mapFn: (m: PhotoDTO) => [m.metadata.cameraData?.lens],
     renderType: FilterRenderType.enum,
   },
- city: {
-  key: 'city',
+  city: {
+    key: 'city',
     name: $localize`City`,
-    mapFn: (m: PhotoDTO): string => m.metadata.positionData?.city,
+    mapFn: (m: PhotoDTO) => [m.metadata.positionData?.city ?? '<unknown>'],
     renderType: FilterRenderType.enum,
   },
   state: {
     key: 'state',
     name: $localize`State`,
-    mapFn: (m: PhotoDTO): string => m.metadata.positionData?.state,
+    mapFn: (m: PhotoDTO) => [m.metadata.positionData?.state],
     renderType: FilterRenderType.enum,
   },
   country: {
     key: 'country',
     name: $localize`Country`,
-    mapFn: (m: PhotoDTO): string => m.metadata.positionData?.country,
+    mapFn: (m: PhotoDTO) => [m.metadata.positionData?.country],
     renderType: FilterRenderType.enum,
   },
 } as const;
 
-type ActiveFilters = {
+export type FilterState = {
   filtersVisible: boolean;
   areFiltersActive: boolean;
   dateFilter: {
     minDate: number;
-  maxDate: number;
-  minFilter: number;
-  maxFilter: number;
+    maxDate: number;
+    minFilter: number;
+    maxFilter: number;
   };
-  selectedFilters: {
-    type: keyof typeof filters;
-    options: Record<string, boolean>;
-  }[]
-}
+  selectedFilters: SelectedFilter[];
+  filterValueCounts: { [k in FilterType]?: Record<string, number | undefined> };
+};
+export type FilterType = keyof typeof filters;
 
 export interface Filter {
+  key: FilterType;
   name: string;
   mapFn: (m: PhotoDTO) => (string | number)[] | (string | number);
   renderType: FilterRenderType;
   isArrayValue?: boolean;
 }
 
-export interface FilterOption {
-  name: string;
-  count: number;
-  selected: boolean;
-}
-
 export interface SelectedFilter {
-  filter: Filter;
-  options: FilterOption[];
+  type: FilterType;
+  options: Record<string, boolean>;
 }
 
 @Injectable()
 export class FilterService {
-  public readonly activeFilters = new BehaviorSubject<ActiveFilters>({
+  public readonly filterState = new BehaviorSubject<FilterState>({
     filtersVisible: false,
     areFiltersActive: false,
     dateFilter: {
@@ -145,16 +141,38 @@ export class FilterService {
         options: {},
       },
     ],
+    filterValueCounts: {},
   });
-  public statistic: { date: Date; endDate: Date; dateStr: string; count: number; max: number; }[] = [];
+  public statistic: {
+    date: Date;
+    endDate: Date;
+    dateStr: string;
+    count: number;
+    max: number;
+  }[] = [];
 
-  private getStatistic(prefiltered: DirectoryContent): { date: Date, endDate: Date, dateStr: string, count: number, max: number }[] {
-    if (!prefiltered ||
-      !prefiltered.media ||
-      prefiltered.media.length === 0) {
+  public filters = Object.values(filters);
+  public filtersMap = filters;
+  
+  private getStatistic(
+    prefiltered: DirectoryContent
+  ): {
+    date: Date;
+    endDate: Date;
+    dateStr: string;
+    count: number;
+    max: number;
+  }[] {
+    if (!prefiltered || !prefiltered.media || prefiltered.media.length === 0) {
       return [];
     }
-    const ret: { date: Date, endDate: Date, dateStr: string, count: number, max: number }[] = [];
+    const ret: {
+      date: Date;
+      endDate: Date;
+      dateStr: string;
+      count: number;
+      max: number;
+    }[] = [];
     const minDate = prefiltered.media.reduce(
       (p, curr) => Math.min(p, curr.metadata.creationDate),
       Number.MAX_VALUE - 1
@@ -189,31 +207,48 @@ export class FilterService {
     const floorDate = (ts: number): number => {
       let d = new Date(ts);
       if (usedDiv >= Y) {
-        const fy = (d.getFullYear());
-        d = new Date(fy - fy % (usedDiv / Y), 0, 1);
+        const fy = d.getFullYear();
+        d = new Date(fy - (fy % (usedDiv / Y)), 0, 1);
       } else if (usedDiv === M) {
         d = new Date(d.getFullYear(), d.getMonth(), 1);
       } else {
-        d = new Date(ts - ts % usedDiv);
+        d = new Date(ts - (ts % usedDiv));
       }
       return d.getTime();
     };
 
     const startMediaDate = new Date(floorDate(minDate));
 
-    prefiltered.media.forEach(m => {
-      const key = Math.floor((floorDate(m.metadata.creationDate) - startMediaDate.getTime()) / 1000 / usedDiv);
+    prefiltered.media.forEach((m) => {
+      const key = Math.floor(
+        (floorDate(m.metadata.creationDate) - startMediaDate.getTime()) /
+          1000 /
+          usedDiv
+      );
 
       const getDate = (index: number) => {
         let d: Date;
         if (usedDiv >= Y) {
-          d = new Date(startMediaDate.getFullYear() + (index * (usedDiv / Y)), 0, 1);
+          d = new Date(
+            startMediaDate.getFullYear() + index * (usedDiv / Y),
+            0,
+            1
+          );
         } else if (usedDiv === M) {
-          d = new Date(startMediaDate.getFullYear(), startMediaDate.getMonth() + index, 1);
+          d = new Date(
+            startMediaDate.getFullYear(),
+            startMediaDate.getMonth() + index,
+            1
+          );
         } else if (usedDiv === D) {
-          d = new Date(startMediaDate.getFullYear(), startMediaDate.getMonth(), startMediaDate.getDate() + index, 1);
+          d = new Date(
+            startMediaDate.getFullYear(),
+            startMediaDate.getMonth(),
+            startMediaDate.getDate() + index,
+            1
+          );
         } else {
-          d = (new Date(startMediaDate.getTime() + (index * usedDiv * 1000)));
+          d = new Date(startMediaDate.getTime() + index * usedDiv * 1000);
         }
         return d;
       };
@@ -230,7 +265,13 @@ export class FilterService {
         } else {
           dStr = 'HH';
         }
-        ret.push({date: getDate(ret.length), endDate: getDate(ret.length + 1), dateStr: dStr, count: 0, max: 0});
+        ret.push({
+          date: getDate(ret.length),
+          endDate: getDate(ret.length + 1),
+          dateStr: dStr,
+          count: 0,
+          max: 0,
+        });
       }
 
       ret[key].count++;
@@ -242,7 +283,7 @@ export class FilterService {
     }
 
     const max = ret.reduce((p, c) => Math.max(p, c.count), 0);
-    ret.forEach(v => v.max = max);
+    ret.forEach((v) => (v.max = max));
     return ret;
   }
 
@@ -252,14 +293,15 @@ export class FilterService {
     return directoryContent.pipe(
       switchMap((dirContent: DirectoryContent) => {
         this.statistic = this.getStatistic(dirContent);
-        this.resetFilters(false);
-        return this.activeFilters.pipe(
+        return this.filterState.pipe(
           map((afilters) => {
-            if (!dirContent || !dirContent.media || (!afilters.filtersVisible && !afilters.areFiltersActive)) {
+            if (
+              !dirContent ||
+              !dirContent.media ||
+              (!afilters.filtersVisible && !afilters.areFiltersActive)
+            ) {
               return dirContent;
             }
-
-
 
             // clone, so the original won't get overwritten
             const c = {
@@ -280,8 +322,10 @@ export class FilterService {
                 Number.MIN_VALUE + 1
               );
               // Add a few sec padding
-              afilters.dateFilter.minDate -= (afilters.dateFilter.minDate % 1000) + 1000;
-              afilters.dateFilter.maxDate += (afilters.dateFilter.maxDate % 1000) + 1000;
+              afilters.dateFilter.minDate -=
+                (afilters.dateFilter.minDate % 1000) + 1000;
+              afilters.dateFilter.maxDate +=
+                (afilters.dateFilter.maxDate % 1000) + 1000;
 
               if (afilters.dateFilter.minFilter === Number.MIN_VALUE) {
                 afilters.dateFilter.minFilter = afilters.dateFilter.minDate;
@@ -310,62 +354,49 @@ export class FilterService {
             // Finally, filter the media accordingly
             // And update the filter selections with those defaults
 
-            const valueMap = new Map(afilters.selectedFilters.map(({type})=> {
-              const valuesForThisMedia = c.media.flatMap(media => {
-                const valuesForThisFilter = filters[type].mapFn(media as PhotoDTO);
-                return Array.isArray(valuesForThisFilter) ? valuesForThisFilter : [valuesForThisFilter];
-              })
-              const counts = new Map<string, number>();
-              for (const value of valuesForThisMedia) {
-                counts.set(value, (counts.get(value) ?? 0) + 1)
-              }
-              return [type, counts] as const;
-            }));
+            // I think I can do *all* of this in one pass
 
-            // If any options exist that are not in the current selection, default
-            // them to selected.
-            const selectedOptions = new Map(afilters.selectedFilters.map(f => [f.type, ({
-              ...Object.fromEntries([...valueMap.get(f.type).keys()].map(([k]) => [k, true])),
-              ...f.options,
-            })]));
+            const filterValueCounts: {
+              [k in FilterType]?: Record<string, number | undefined>;
+            } = {};
 
-   
+            function* doFilter() {
+              for (const item of c.media) {
+                const filteredOut = afilters.selectedFilters.reduce(
+                  (filteredOut, { type, options }) => {
+                    const values = filters[type].mapFn(item as PhotoDTO) ?? [];
+                    const counts = (filterValueCounts[type] =
+                      filterValueCounts[type] ?? {});
 
-            // filters
-            for (const f of afilters.selectedFilters) {
-              c.media = c.media.filter(media => {
-                const valuesForThisFilter = filters[f.type].mapFn(media as PhotoDTO);
-                const normalizedArray = Array.isArray(valuesForThisFilter) ? valuesForThisFilter : [valuesForThisFilter];
-                return selectedOptions.get(f.type)?.
-              })
-            
-              f.options = Object.values(valueMap)
-                .filter((o) => o.count > 0)
-                .sort((a, b) => b.count - a.count);
-
-              /* Apply filters */
-              f.options.forEach((opt) => {
-                if (opt.selected) {
-                  return;
-                }
-                if (f.filter.isArrayValue) {
-                  c.media = c.media.filter((m) => {
-                    const mapped = f.filter.mapFn(m as PhotoDTO) as string[];
-                    if (!mapped) {
-                      return true;
+                    for (const value of values) {
+                      counts[value] = (counts[value] ?? 0) + 1;
+                      if (options[value] === undefined) {
+                        options[value] = true; // Add any unknown values to the filter
+                      }
                     }
-                    return mapped.indexOf(opt.name) === -1;
-                  });
-                } else {
-                  c.media = c.media.filter(
-                    (m) =>
-                      (f.filter.mapFn(m as PhotoDTO) as string) !== opt.name
-                  );
+                    return filteredOut || values.every((v) => !options[v]);
+                
+                  },
+                  false
+                );
+                if (!filteredOut) {
+                  yield item;
                 }
-              });
+              }
             }
-            // If the number of photos did not change, the filters are not active
-            afilters.areFiltersActive = c.media.length !== dirContent.media.length;
+
+            c.media = [...doFilter()];
+            afilters.filterValueCounts = filterValueCounts;
+            afilters.areFiltersActive =
+              c.media.length !== dirContent.media.length;
+            for (const {type, options} of afilters.selectedFilters) {
+              for (const option of Object.keys(options)) {
+                if (!filterValueCounts[type]?.[option]) {
+                  delete options[option]
+                }
+              }
+            }
+
             return c;
           })
         );
@@ -374,28 +405,29 @@ export class FilterService {
   }
 
   public onFilterChange(): void {
-    this.activeFilters.next(this.activeFilters.value);
+    this.filterState.next(this.filterState.value);
   }
 
   setShowingFilters(value: boolean): void {
-    if (this.activeFilters.value.filtersVisible === value) {
+    if (this.filterState.value.filtersVisible === value) {
       return;
     }
-    this.activeFilters.value.filtersVisible = value;
-    if ((!this.activeFilters.value.filtersVisible && !this.activeFilters.value.areFiltersActive)) {
+    this.filterState.value.filtersVisible = value;
+    if (
+      !this.filterState.value.filtersVisible &&
+      !this.filterState.value.areFiltersActive
+    ) {
       this.resetFilters(false);
     }
     this.onFilterChange();
   }
 
   resetFilters(triggerChangeDetection = true): void {
-    this.activeFilters.value.dateFilter.minFilter = Number.MIN_VALUE;
-    this.activeFilters.value.dateFilter.maxFilter = Number.MAX_VALUE;
-    this.activeFilters.value.selectedFilters.forEach((f) => (f.options = []));
+    this.filterState.value.dateFilter.minFilter = Number.MIN_VALUE;
+    this.filterState.value.dateFilter.maxFilter = Number.MAX_VALUE;
+    this.filterState.value.selectedFilters.forEach((f) => (f.options = {}));
     if (triggerChangeDetection) {
       this.onFilterChange();
     }
   }
 }
-
-

--- a/src/frontend/app/ui/gallery/filter/filter.service.ts
+++ b/src/frontend/app/ui/gallery/filter/filter.service.ts
@@ -43,7 +43,7 @@ const filters = {
   caption: {
     key: 'caption',
     name: $localize`Caption`,
-    mapFn: (m: PhotoDTO) => [m.metadata.caption],
+    mapFn: (m: PhotoDTO) => [m.metadata.caption ?? '<unknown>'],
     renderType: FilterRenderType.enum,
   },
   rating: {
@@ -55,13 +55,13 @@ const filters = {
   camera: {
     key: 'camera',
     name: $localize`Camera`,
-    mapFn: (m: PhotoDTO) => [m.metadata.cameraData?.model],
+    mapFn: (m: PhotoDTO) => [m.metadata.cameraData?.model ?? '<unknown>'],
     renderType: FilterRenderType.enum,
   },
   lens: {
     key: 'lens',
     name: $localize`Lens`,
-    mapFn: (m: PhotoDTO) => [m.metadata.cameraData?.lens],
+    mapFn: (m: PhotoDTO) => [m.metadata.cameraData?.lens ?? '<unknown>'],
     renderType: FilterRenderType.enum,
   },
   city: {
@@ -73,13 +73,13 @@ const filters = {
   state: {
     key: 'state',
     name: $localize`State`,
-    mapFn: (m: PhotoDTO) => [m.metadata.positionData?.state],
+    mapFn: (m: PhotoDTO) => [m.metadata.positionData?.state ?? '<unknown>'],
     renderType: FilterRenderType.enum,
   },
   country: {
     key: 'country',
     name: $localize`Country`,
-    mapFn: (m: PhotoDTO) => [m.metadata.positionData?.country],
+    mapFn: (m: PhotoDTO) => [m.metadata.positionData?.country ?? '<unknown>'],
     renderType: FilterRenderType.enum,
   },
 } as const;

--- a/src/frontend/app/ui/gallery/filter/filter.service.ts
+++ b/src/frontend/app/ui/gallery/filter/filter.service.ts
@@ -152,25 +152,15 @@ export class FilterService {
   public filters = Object.values(filters);
   public filtersMap = filters;
   
-  private getStatistic(
-    prefiltered: DirectoryContent
-  ): {
-    date: Date;
-    endDate: Date;
-    dateStr: string;
-    count: number;
-    max: number;
-  }[] {
-    if (!prefiltered || !prefiltered.media || prefiltered.media.length === 0) {
+  public statistic: { date: Date; endDate: Date; dateStr: string; count: number; max: number; }[] = [];
+
+  private getStatistic(prefiltered: DirectoryContent): { date: Date, endDate: Date, dateStr: string, count: number, max: number }[] {
+    if (!prefiltered ||
+      !prefiltered.media ||
+      prefiltered.media.length === 0) {
       return [];
     }
-    const ret: {
-      date: Date;
-      endDate: Date;
-      dateStr: string;
-      count: number;
-      max: number;
-    }[] = [];
+    const ret: { date: Date, endDate: Date, dateStr: string, count: number, max: number }[] = [];
     const minDate = prefiltered.media.reduce(
       (p, curr) => Math.min(p, curr.metadata.creationDate),
       Number.MAX_VALUE - 1
@@ -205,48 +195,31 @@ export class FilterService {
     const floorDate = (ts: number): number => {
       let d = new Date(ts);
       if (usedDiv >= Y) {
-        const fy = d.getFullYear();
-        d = new Date(fy - (fy % (usedDiv / Y)), 0, 1);
+        const fy = (d.getFullYear());
+        d = new Date(fy - fy % (usedDiv / Y), 0, 1);
       } else if (usedDiv === M) {
         d = new Date(d.getFullYear(), d.getMonth(), 1);
       } else {
-        d = new Date(ts - (ts % usedDiv));
+        d = new Date(ts - ts % usedDiv);
       }
       return d.getTime();
     };
 
     const startMediaDate = new Date(floorDate(minDate));
 
-    prefiltered.media.forEach((m) => {
-      const key = Math.floor(
-        (floorDate(m.metadata.creationDate) - startMediaDate.getTime()) /
-          1000 /
-          usedDiv
-      );
+    prefiltered.media.forEach(m => {
+      const key = Math.floor((floorDate(m.metadata.creationDate) - startMediaDate.getTime()) / 1000 / usedDiv);
 
       const getDate = (index: number) => {
         let d: Date;
         if (usedDiv >= Y) {
-          d = new Date(
-            startMediaDate.getFullYear() + index * (usedDiv / Y),
-            0,
-            1
-          );
+          d = new Date(startMediaDate.getFullYear() + (index * (usedDiv / Y)), 0, 1);
         } else if (usedDiv === M) {
-          d = new Date(
-            startMediaDate.getFullYear(),
-            startMediaDate.getMonth() + index,
-            1
-          );
+          d = new Date(startMediaDate.getFullYear(), startMediaDate.getMonth() + index, 1);
         } else if (usedDiv === D) {
-          d = new Date(
-            startMediaDate.getFullYear(),
-            startMediaDate.getMonth(),
-            startMediaDate.getDate() + index,
-            1
-          );
+          d = new Date(startMediaDate.getFullYear(), startMediaDate.getMonth(), startMediaDate.getDate() + index, 1);
         } else {
-          d = new Date(startMediaDate.getTime() + index * usedDiv * 1000);
+          d = (new Date(startMediaDate.getTime() + (index * usedDiv * 1000)));
         }
         return d;
       };
@@ -263,13 +236,7 @@ export class FilterService {
         } else {
           dStr = 'HH';
         }
-        ret.push({
-          date: getDate(ret.length),
-          endDate: getDate(ret.length + 1),
-          dateStr: dStr,
-          count: 0,
-          max: 0,
-        });
+        ret.push({date: getDate(ret.length), endDate: getDate(ret.length + 1), dateStr: dStr, count: 0, max: 0});
       }
 
       ret[key].count++;
@@ -281,7 +248,7 @@ export class FilterService {
     }
 
     const max = ret.reduce((p, c) => Math.max(p, c.count), 0);
-    ret.forEach((v) => (v.max = max));
+    ret.forEach(v => v.max = max);
     return ret;
   }
 

--- a/src/frontend/app/ui/gallery/filter/filter.service.ts
+++ b/src/frontend/app/ui/gallery/filter/filter.service.ts
@@ -306,8 +306,8 @@ export class FilterService {
               } = {};
 
               for (const item of c.media) {
-                const filteredOut = afilters.selectedFilters.reduce(
-                  (filteredOut, { type, options }) => {
+                const keep = afilters.selectedFilters.reduce(
+                  (keep, { type, options }) => {
                     const values = filters[type].mapFn(item as PhotoDTO) ?? [];
                     const counts = (filterValueCounts[type] =
                       filterValueCounts[type] ?? {});
@@ -319,17 +319,17 @@ export class FilterService {
                       }
                     }
                     return (
-                      filteredOut ||
+                      !keep ||
                       (values.length > 0 &&
                         !options.some(
                           ({ name, selected }) =>
-                            selected && !values.includes(name)
+                            selected && values.includes(name)
                         ))
                     );
                   },
-                  false
+                  true
                 );
-                if (!filteredOut) {
+                if (keep) {
                   yield item;
                 }
               }
@@ -348,6 +348,8 @@ export class FilterService {
                 (option) => filterValueCounts[filter.type]?.[option.name]
               );
             }
+
+            console.info(afilters.selectedFilters)
 
             c.media = filteredMedia;
             return c;

--- a/src/frontend/app/ui/gallery/filter/filter.service.ts
+++ b/src/frontend/app/ui/gallery/filter/filter.service.ts
@@ -2,9 +2,7 @@ import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { PhotoDTO } from '../../../../../common/entities/PhotoDTO';
 import { DirectoryContent } from '../contentLoader.service';
-import { debounceTime, map, switchMap } from 'rxjs/operators';
-import { Filters } from 'fluent-ffmpeg';
-import { debug } from 'console';
+import { map, switchMap } from 'rxjs/operators';
 
 export enum FilterRenderType {
   enum = 1,
@@ -347,15 +345,6 @@ export class FilterService {
               afilters.dateFilter.maxFilter = Number.MAX_VALUE;
             }
 
-            // this needs to:
-            // Build an array with all of the selected filter values for all of the media
-            // Build a map with the counts of all of the selected filter values for all of the media
-            // Build a map with all of the filter selections, including considering the unknown ones
-            // Finally, filter the media accordingly
-            // And update the filter selections with those defaults
-
-            // I think I can do *all* of this in one pass
-
             const filterValueCounts: {
               [k in FilterType]?: Record<string, number | undefined>;
             } = {};
@@ -374,8 +363,7 @@ export class FilterService {
                         options.push({name: value, selected: true}); // Add any unknown values to the filter
                       }
                     }
-                    return filteredOut || values.every((v) => !options.some(({name, selected}) => selected && name === v));
-                
+                    return filteredOut || (values.length > 0 && values.every((v) => !options.some(({name, selected}) => selected && name === v)));
                   },
                   false
                 );

--- a/src/frontend/app/ui/gallery/gallery.component.ts
+++ b/src/frontend/app/ui/gallery/gallery.component.ts
@@ -179,6 +179,7 @@ export class GalleryComponent implements OnInit, OnDestroy {
   };
 
   private onContentChange = (content: GroupedDirectoryContent): void => {
+    console.info('content changed', this.directoryContent?.mediaGroups)
     if (!content) {
       return;
     }

--- a/src/frontend/app/ui/gallery/gallery.component.ts
+++ b/src/frontend/app/ui/gallery/gallery.component.ts
@@ -179,7 +179,6 @@ export class GalleryComponent implements OnInit, OnDestroy {
   };
 
   private onContentChange = (content: GroupedDirectoryContent): void => {
-    console.info('content changed', this.directoryContent?.mediaGroups)
     if (!content) {
       return;
     }

--- a/src/frontend/app/ui/gallery/navigator/navigator.gallery.component.html
+++ b/src/frontend/app/ui/gallery/navigator/navigator.gallery.component.html
@@ -45,8 +45,8 @@
             </ng-container>
             <ng-container *ngIf="ItemCount> 0">
                 <a class="btn btn-outline-secondary btn-navigator"
-                   [class.btn-secondary]="filterService.activeFilters.value.areFiltersActive"
-                   [class.btn-outline-secondary]="!filterService.activeFilters.value.areFiltersActive"
+                   [class.btn-secondary]="filterService.filterState.value.areFiltersActive"
+                   [class.btn-outline-secondary]="!filterService.filterState.value.areFiltersActive"
                    (click)="showFilters = ! showFilters">
                     <ng-icon name="ionFunnelOutline"
                              title="Filters" i18n-title></ng-icon>

--- a/test/common/unit/Utils.spec.ts
+++ b/test/common/unit/Utils.spec.ts
@@ -62,7 +62,7 @@ describe('Utils', () => {
       for (const item of items) yield item;
       return ret;
     }
-    expect(Utils.collect(generator(['a', 'b'], 'z'))).to.be.equal([['a', 'b'], 'z'])
-    expect(Utils.collect(generator(['a', 'b']))).to.be.equal([['a', 'b'], undefined])
+    expect(Utils.collect(generator(['a', 'b'], 'z'))).to.deep.equal([['a', 'b'], 'z'])
+    expect(Utils.collect(generator(['a', 'b']))).to.deep.equal([['a', 'b'], undefined])
   })
 });

--- a/test/common/unit/Utils.spec.ts
+++ b/test/common/unit/Utils.spec.ts
@@ -56,4 +56,13 @@ describe('Utils', () => {
     expect(Utils.equalsFilter({a: 0}, {b: 0})).to.be.equal(false);
     expect(Utils.equalsFilter({a: 0}, {a: 0})).to.be.equal(true);
   });
+
+  it('should properly iterate generators', () => {
+    function * generator(items: unknown[], ret?: unknown) {
+      for (const item of items) yield item;
+      return ret;
+    }
+    expect(Utils.collect(generator(['a', 'b'], 'z'))).to.be.equal([['a', 'b'], 'z'])
+    expect(Utils.collect(generator(['a', 'b']))).to.be.equal([['a', 'b'], undefined])
+  })
 });

--- a/test/cypress/e2e/gallery.cy.ts
+++ b/test/cypress/e2e/gallery.cy.ts
@@ -16,7 +16,8 @@ describe('Gallery', () => {
   it('Gallery should open', () => {
     cy.get('.mb-0 > :nth-child(1) > .nav-link').contains('Gallery');
   });
-  it('Gallery should filter', () => {
+
+  it('Gallery should allow changing filter types, and filter with toggle-only', () => {
     cy.wait('@getContent');
     cy.get('app-gallery-navbar  ng-icon[name="ionFunnelOutline"]').click({scrollBehavior: false});
     cy.get('app-gallery-navbar #gallery-filter-0').select('City', {force: true});
@@ -33,6 +34,19 @@ describe('Gallery', () => {
     // should this photo be visible
     cy.get('.photo-container > img[alt="IMG_5910.jpg"]');
     cy.get('.photo-container > img[alt="IMG_6220.jpg"]').should('not.exist');
+  });
+
+  it('Gallery should cascade filters left-to-right', () => {
+    cy.wait('@getContent');
+    cy.get('app-gallery-navbar  ng-icon[name="ionFunnelOutline"]').click({scrollBehavior: false});
+
+    cy.get('app-gallery-navbar #gallery-filter-1').siblings('.filter-column').contains('<no face>').parent().contains('15');
+    cy.get('.photo-container > img[alt="IMG_8751.jpg"]');
+
+    cy.get('app-gallery-navbar #gallery-filter-0').siblings('.filter-column').contains('USA Road trip').click({scrollBehavior: false, force: true});
+    cy.get('app-gallery-navbar #gallery-filter-1').siblings('.filter-column').contains('<no face>').parent().contains('7')
+
+    cy.get('.photo-container > img[alt="IMG_8751.jpg"]').should('not.exist');
   });
 
 


### PR DESCRIPTION
Based on #780

## Why

Currently, the active filter state intermingles:
- Filter type implementation: `mapFn`, `name`, etc.
- Library data: count of items with various filter values
- UI data: selected filter types and options

Because of this, even starting on #776 isn't really feasible.

## What

This PR separates out:
- Filter type implementation: `FilterService.filters` + `FilterService.filtersMap`
- Library data: `FilterService.filterState.filterValueCounts`
- UI data: `FilterServie.filterState.selectedFilters`

## What else

~~This also fixes an odd issue where the leftward filters impact the counts on filters to their right, but not vice-verse. Now filters all report all values in the date-filtered photo set. **If this is intended**, I can update it to be consistent instead of left-to-right.~~ This _was_ intended - I just misunderstood the desired behavior.

- [ ] Revert change to intended left-to-right filter behavior

Additionally, I've addressed a number of inconsistencies and type issues - removing casts and making `mapFn` always return `string[] | undefined`.
