### PR TITLE
Tiny fix of error in German translation

### DIFF
--- a/src/frontend/translate/messages.de.xlf
+++ b/src/frontend/translate/messages.de.xlf
@@ -1936,7 +1936,7 @@
           <context context-type="sourcefile">src/common/config/public/ClientConfig.ts</context>
           <context context-type="linenumber">821</context>
         </context-group>
-        <target>Fügt ein Knopf hinzu, um die Dateistruktur zu "glätten" in dem der Inhalt aller Unterverzeichnisse aufgelistet wird. (Funktioniert nicht, falls die Galerie mehrere Verzeichnisse mit demselben Pfad hat.)</target>
+        <target>Fügt einen Knopf hinzu, um die Dateistruktur zu "glätten", indem der Inhalt aller Unterverzeichnisse aufgelistet wird. (Funktioniert nicht, falls die Galerie mehrere Verzeichnisse mit demselben Pfad hat.)</target>
       </trans-unit>
       <trans-unit id="2057017984457052518" datatype="html">
         <source>Default grid size</source>


### PR DESCRIPTION
Fix to address [a comment](https://github.com/bpatrik/pigallery2/commit/161a5fc417258b63fcc5e9900f3d0676340952c4#commitcomment-134117343) pointing out an erroneous translation / mostly bad wording.