### PR TITLE
Issue 814 : Name the zip file after the folder name

### DIFF
--- a/src/backend/middlewares/GalleryMWs.ts
+++ b/src/backend/middlewares/GalleryMWs.ts
@@ -84,6 +84,7 @@ export class GalleryMWs {
     res: Response,
     next: NextFunction
   ): Promise<void> {
+    var contentDisposition = require('content-disposition')
     if (Config.Gallery.NavBar.enableDownloadZip === false) {
       return next();
     }
@@ -102,7 +103,16 @@ export class GalleryMWs {
 
     try {
       res.set('Content-Type', 'application/zip');
-      res.set('Content-Disposition', 'attachment; filename=Gallery.zip');
+      var zipName = directoryName;
+      if (zipName.endsWith('/')) {
+        zipName=zipName.substring(0,zipName.length-1);
+      }
+      zipName = zipName.substring(zipName.lastIndexOf('/')+1);
+      if (zipName=='') {
+        zipName='gallery';
+      }
+      zipName=zipName+'.zip';
+      res.set('Content-Disposition', contentDisposition(zipName));
 
       const archive = archiver('zip', {
         store: true, // disable compression

--- a/src/backend/middlewares/GalleryMWs.ts
+++ b/src/backend/middlewares/GalleryMWs.ts
@@ -84,7 +84,7 @@ export class GalleryMWs {
     res: Response,
     next: NextFunction
   ): Promise<void> {
-    var contentDisposition = require('content-disposition')
+    const contentDisposition = require('content-disposition')
     if (Config.Gallery.NavBar.enableDownloadZip === false) {
       return next();
     }
@@ -103,7 +103,7 @@ export class GalleryMWs {
 
     try {
       res.set('Content-Type', 'application/zip');
-      var zipName = directoryName;
+      let zipName = directoryName;
       if (zipName.endsWith('/')) {
         zipName=zipName.substring(0,zipName.length-1);
       }


### PR DESCRIPTION
The name of the zip when downloading a folder should be named after the folder.
For root, default will be gallery.zip