### PR TITLE
Fix video not loading #808

### DIFF
--- a/src/backend/routes/GalleryRouter.ts
+++ b/src/backend/routes/GalleryRouter.ts
@@ -16,9 +16,9 @@ export class GalleryRouter {
     this.addGetImageIcon(app);
     this.addGetVideoIcon(app);
     this.addGetResizedPhoto(app);
+    this.addGetBestFitVideo(app);
     this.addGetVideoThumbnail(app);
     this.addGetImage(app);
-    this.addGetBestFitVideo(app);
     this.addGetVideo(app);
     this.addGetMetaFile(app);
     this.addGetBestFitMetaFile(app);


### PR DESCRIPTION
Route collision with thumbnail path and video path. Results in videos not loading properly.

Changing the route definition order fixes the issue.