### PR TITLE
Manually add vips-heif

### DIFF
--- a/docker/alpine/Dockerfile.build
+++ b/docker/alpine/Dockerfile.build
@@ -2,7 +2,7 @@
 #-----------------------------------------
 FROM node:18-alpine3.17 AS builder
 RUN apk add --update-cache --repository https://alpine.global.ssl.fastly.net/alpine/v3.17/community/ \
-  python3 build-base sqlite-dev sqlite-libs vips-dev fftw-dev gcc g++ make libc6-compat && ln -snf /usr/bin/python3 /usr/bin/python
+  python3 build-base sqlite-dev sqlite-libs vips-dev vips-heif fftw-dev gcc g++ make libc6-compat && ln -snf /usr/bin/python3 /usr/bin/python
 COPY pigallery2-release /app
 WORKDIR /app
 RUN npm install --unsafe-perm
@@ -27,7 +27,7 @@ ENV NODE_ENV=production \
 
 EXPOSE 80
 RUN apk add --update-cache --repository https://alpine.global.ssl.fastly.net/alpine/v3.17/community/ \
-    vips vips-cpp ffmpeg
+    vips vips-cpp vips-heif ffmpeg
 COPY --from=builder /app /app
 VOLUME ["/app/data/config", "/app/data/db", "/app/data/images", "/app/data/tmp"]
 


### PR DESCRIPTION
Unlike debian that pulled heif libs when install vips-dev, alpine need to install this heif separately.