### PR TITLE
Lightbox: fix mouse wheel behavior and add horizontal scroll feature.

### DIFF
--- a/src/frontend/app/ui/gallery/lightbox/controls/controls.lightbox.gallery.component.ts
+++ b/src/frontend/app/ui/gallery/lightbox/controls/controls.lightbox.gallery.component.ts
@@ -146,13 +146,25 @@ export class ControlsLightboxComponent implements OnDestroy, OnInit, OnChanges {
     }
   }
 
-  wheel($event: { deltaY: number }): void {
-    if (!this.activePhoto || this.activePhoto.gridMedia.isVideo()) {
+  wheel($event: { deltaX: number, deltaY: number }): void {
+    if (!this.activePhoto) {
+      return;
+    }
+    if ($event.deltaX < 0) {
+      if (this.navigation.hasPrev) {
+        this.previousPhoto.emit();
+      }
+    } else if ($event.deltaX > 0) {
+      if (this.navigation.hasNext) {
+        this.nextMediaManuallyTriggered();
+      }
+    }
+    if (this.activePhoto.gridMedia.isVideo()) {
       return;
     }
     if ($event.deltaY < 0) {
       this.zoomIn();
-    } else {
+    } else if ($event.deltaY > 0) {
       this.zoomOut();
     }
   }
@@ -537,4 +549,3 @@ export class ControlsLightboxComponent implements OnDestroy, OnInit, OnChanges {
   }
 
 }
-


### PR DESCRIPTION
This addresses my issue #835 and is two fold:
1. Previously, any non-negative deltaY change to the mouse wheel would cause a photo in the lightbox zoom out, regardless of the direction. I have changed this so that zoom out is only possible with positive deltaY values.
2. I have added the option to scroll through photos in the lightbox using horizontal scrolling (deltaX). This mimics the behavior of left/right arrow and allows for navigation solely with the mouse. I've also changed it so you _can_ use this scroll on videos. The previous behavior of canceling zoom on videos remains.

Thanks for the consideration!