### PR TITLE
Add excludeDir to extension interface

### DIFF
--- a/src/backend/model/extension/ExtensionManager.ts
+++ b/src/backend/model/extension/ExtensionManager.ts
@@ -54,6 +54,7 @@ export class ExtensionManager implements IObjectManager {
           invalidateDirectoryCovers: new ExtensionEvent(),
         },
         DiskManager: {
+          excludeDir: new ExtensionEvent(),
           scanDirectory: new ExtensionEvent()
         },
         ImageRenderer: {

--- a/src/backend/model/extension/IExtension.ts
+++ b/src/backend/model/extension/IExtension.ts
@@ -73,6 +73,11 @@ export interface IExtensionEvents {
      * photos, videos and metafiles
      */
     DiskManager: {
+      excludeDir: IExtensionEvent<[{
+        name: string,
+        parentDirRelativeName: string,
+        parentDirAbsoluteName: string
+      }], boolean>,
       scanDirectory: IExtensionEvent<[
         string,
         DirectoryScanSettings], ParentDirectoryDTO>

--- a/src/backend/model/fileaccess/DiskManager.ts
+++ b/src/backend/model/fileaccess/DiskManager.ts
@@ -49,19 +49,20 @@ export class DiskManager {
     return path.basename(dirPath);
   }
 
-  public static async excludeDir(
+  @ExtensionDecorator(e => e.gallery.DiskManager.excludeDir)
+  public static async excludeDir(dir: {
     name: string,
-    relativeDirectoryName: string,
-    absoluteDirectoryName: string
-  ): Promise<boolean> {
+    parentDirRelativeName: string,
+    parentDirAbsoluteName: string
+  }): Promise<boolean> {
     if (
       Config.Indexing.excludeFolderList.length === 0 &&
       Config.Indexing.excludeFileList.length === 0
     ) {
       return false;
     }
-    const absoluteName = path.normalize(path.join(absoluteDirectoryName, name));
-    const relativeName = path.normalize(path.join(relativeDirectoryName, name));
+    const absoluteName = path.normalize(path.join(dir.parentDirAbsoluteName, dir.name));
+    const relativeName = path.normalize(path.join(dir.parentDirRelativeName, dir.name));
 
     for (const exclude of Config.Indexing.excludeFolderList) {
       if (exclude.startsWith('/')) {
@@ -73,7 +74,7 @@ export class DiskManager {
           return true;
         }
       } else {
-        if (exclude === name) {
+        if (exclude === dir.name) {
           return true;
         }
       }
@@ -155,11 +156,11 @@ export class DiskManager {
           if (
             settings.noDirectory === true ||
             settings.coverOnly === true ||
-            (await DiskManager.excludeDir(
-              file,
-              relativeDirectoryName,
-              absoluteDirectoryName
-            ))
+            (await DiskManager.excludeDir({
+              name: file,
+              parentDirRelativeName: relativeDirectoryName,
+              parentDirAbsoluteName: absoluteDirectoryName
+            }))
           ) {
             continue;
           }


### PR DESCRIPTION
Without this, the mechanism to exclude a directory from indexing is a bit strange.  I had to use the `scanDirectory.after` hook, then remove elements from the `output.directories` array.

In order to make the extension hook a bit more developer-friendly, I also changed the arguments to the `excludeDir` function to be a dictionary instead of just an array (or tuple?) of strings.

Tested and working against commit f5f34c5 with a tweaked version of my 'digikam connector' extension.