### PR TITLE
Feature/location info (#9)

### DIFF
--- a/src/frontend/app/ui/gallery/grid/photo/photo.grid.gallery.component.ts
+++ b/src/frontend/app/ui/gallery/grid/photo/photo.grid.gallery.component.ts
@@ -134,10 +134,10 @@ export class GalleryPhotoComponent implements IRenderable, OnInit, OnDestroy {
   }
 
   getPositionText(): string {
-    if (!this.gridMedia || !this.gridMedia.isPhoto()) {
+    if (!this.gridMedia || !this.gridMedia.isPhoto() || !(this.gridMedia.media as PhotoDTO).metadata.positionData) {
       return '';
     }
-    return (
+    return ( //not much space in the gridview, so we only deliver city, or state or country
         (this.gridMedia.media as PhotoDTO).metadata.positionData.city ||
         (this.gridMedia.media as PhotoDTO).metadata.positionData.state ||
         (this.gridMedia.media as PhotoDTO).metadata.positionData.country || ''

--- a/src/frontend/app/ui/gallery/lightbox/controls/controls.lightbox.gallery.component.ts
+++ b/src/frontend/app/ui/gallery/lightbox/controls/controls.lightbox.gallery.component.ts
@@ -510,11 +510,14 @@ export class ControlsLightboxComponent implements OnDestroy, OnInit, OnChanges {
       case LightBoxTitleTexts.date:
         return this.datePipe.transform(m.metadata.creationDate, 'longDate', m.metadata.creationDateOffset);
       case LightBoxTitleTexts.location:
-        return (
-          m.metadata.positionData?.city ||
-          m.metadata.positionData?.state ||
-          m.metadata.positionData?.country || ''
-        ).trim();
+        if (!m.metadata.positionData) {
+          return '';
+        }
+        return [
+          m.metadata.positionData.city,
+          m.metadata.positionData.state,
+          m.metadata.positionData.country
+        ].filter(elm => elm).join(', ').trim(); //Filter removes empty elements, join concats the values separated by ', '
       case LightBoxTitleTexts.camera:
         return m.metadata.cameraData?.model;
       case LightBoxTitleTexts.lens:

--- a/src/frontend/app/ui/gallery/lightbox/infopanel/info-panel.lightbox.gallery.component.ts
+++ b/src/frontend/app/ui/gallery/lightbox/infopanel/info-panel.lightbox.gallery.component.ts
@@ -183,17 +183,11 @@ export class InfoPanelLightboxComponent implements OnInit, OnChanges {
     if (!(this.media as PhotoDTO).metadata.positionData) {
       return '';
     }
-    let str =
-        (this.media as PhotoDTO).metadata.positionData.city ||
-        (this.media as PhotoDTO).metadata.positionData.state ||
-        '';
-
-    if (str.length !== 0) {
-      str += ', ';
-    }
-    str += (this.media as PhotoDTO).metadata.positionData.country || '';
-
-    return str;
+    return [
+      (this.media as PhotoDTO).metadata.positionData.city,
+      (this.media as PhotoDTO).metadata.positionData.state,
+      (this.media as PhotoDTO).metadata.positionData.country
+    ].filter(elm => elm).join(', ').trim(); //Filter removes empty elements, join concats the values separated by ', '
   }
 
   close(): void {


### PR DESCRIPTION
* Show comma-separated city, state and country in infobox and in gallery mode. All of the values that are non-empty will be shown.

Before:
![image](https://github.com/grasdk/pigallery2/assets/115414609/419fd155-339a-4332-aa6c-64cad4d51f6b)

After:
![image](https://github.com/grasdk/pigallery2/assets/115414609/69cdb423-f8ce-40ad-93fa-3b5925540d38)

