### PR TITLE
Deal with rating missing in XMP sidecars

### DIFF
--- a/src/backend/model/fileaccess/MetadataLoader.ts
+++ b/src/backend/model/fileaccess/MetadataLoader.ts
@@ -175,7 +175,10 @@ export class MetadataLoader {
                 delete (sidecarData as any)['xap'];
               }
               if ((sidecarData as SideCar).xmp !== undefined) {
-                if ((sidecarData as SideCar).xmp.Rating !== undefined) {
+                if (
+                    (sidecarData as SideCar).xmp.Rating !== undefined &&
+                    (sidecarData as SideCar).xmp.Rating > 0
+                ) {
                   metadata.rating = (sidecarData as SideCar).xmp.Rating;
                 }
                 if (
@@ -651,7 +654,10 @@ export class MetadataLoader {
                   delete (sidecarData as any)['xap'];
                 }
                 if ((sidecarData as SideCar).xmp !== undefined) {
-                  if ((sidecarData as SideCar).xmp.Rating !== undefined) {
+                  if (
+                    (sidecarData as SideCar).xmp.Rating !== undefined &&
+                    (sidecarData as SideCar).xmp.Rating > 0
+                  ) {
                     metadata.rating = (sidecarData as SideCar).xmp.Rating;
                   }
                   if (

--- a/test/backend/assets/sidecar/metadata_v2.json
+++ b/test/backend/assets/sidecar/metadata_v2.json
@@ -10,6 +10,5 @@
     "book",
     "first",
     "second"
-  ],
-  "rating": 0
+  ]
 }


### PR DESCRIPTION
Avoid getting Rating of 0 when rating metadata is not included in a sidecar.