### PR TITLE
Fixes for extension config loading (issue #847)

### DIFF
--- a/src/backend/model/extension/ExtensionManager.ts
+++ b/src/backend/model/extension/ExtensionManager.ts
@@ -12,6 +12,7 @@ import {SQLConnection} from '../database/SQLConnection';
 import {ExtensionObject} from './ExtensionObject';
 import {ExtensionDecoratorObject} from './ExtensionDecorator';
 import * as util from 'util';
+import {ServerExtensionsEntryConfig} from '../../../common/config/private/subconfigs/ServerExtensionsConfig';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const exec = util.promisify(require('child_process').exec);
 
@@ -79,6 +80,14 @@ export class ExtensionManager implements IObjectManager {
       );
     extList.sort();
 
+    // delete not existing extensions
+    Config.Extensions.extensions = Config.Extensions.extensions.filter(ec => extList.indexOf(ec.path) !== -1);
+
+
+    // Add new extensions
+    const ePaths = Config.Extensions.extensions.map(ec => ec.path);
+    extList.filter(ep => ePaths.indexOf(ep) === -1).forEach(ep =>
+      Config.Extensions.extensions.push(new ServerExtensionsEntryConfig(ep)));
 
     Logger.debug(LOG_TAG, 'Extensions found: ', JSON.stringify(Config.Extensions.extensions.map(ec => ec.path)));
   }

--- a/src/common/config/private/Config.ts
+++ b/src/common/config/private/Config.ts
@@ -6,8 +6,12 @@ import * as path from 'path';
 
 const pre = ConfigClassBuilder.attachPrivateInterface(new PrivateConfigClass());
 try {
+  //NOTE: can possibly remove this saveIfNotExist hack if typeconfig issue #27 is fixed
+  const origSaveIfNotExist = (pre.__options as any).saveIfNotExist;
+  (pre.__options as any).saveIfNotExist = false;
   pre.loadSync();
+  (pre.__options as any).saveIfNotExist = origSaveIfNotExist;
 } catch (e) { /* empty */ }
-ExtensionConfigTemplateLoader.Instance.init(path.join(__dirname, '/../../../../', pre.Extensions.folder));
+ExtensionConfigTemplateLoader.Instance.init(pre.Extensions.folder);
 
 export const Config = ExtensionConfigWrapper.originalSync(true);


### PR DESCRIPTION
* Actually add/remove extensions from `Config.Extensions.extensions`
* Fix the file path where `ExtensionConfigTemplateLoader` looks for extensions
* Prevent the first `loadSync()` call from creating a `config.json` file
  Works around part of the issues caused by bpatrik/typeconfig#27

This seems to fix the problems of generating a fresh config with extension settings, saving extension config changes to the file, and loading extension settings from a config file that already includes them.

As noted in #847, this isn't a complete fix.  There's still the problem of adding an extension to an existing install.  I don't think that can be fixed in pigallery2.  I think that needs to be fixed in typeconfig.