### PR TITLE
History fix

### DIFF
--- a/src/frontend/app/ui/gallery/grid/grid.gallery.component.ts
+++ b/src/frontend/app/ui/gallery/grid/grid.gallery.component.ts
@@ -193,7 +193,6 @@ export class GalleryGridComponent
   photoClicked(media: MediaDTO): void {
     this.router.navigate([], {
       queryParams: this.queryService.getParams({media}),
-      replaceUrl: true,
     });
   }
 
@@ -403,7 +402,6 @@ export class GalleryGridComponent
     if (groupIndex === -1) {
       this.router.navigate([], {
         queryParams: this.queryService.getParams(),
-        replaceUrl: true,
       });
       return;
     }

--- a/src/frontend/app/ui/gallery/grid/grid.gallery.component.ts
+++ b/src/frontend/app/ui/gallery/grid/grid.gallery.component.ts
@@ -400,9 +400,7 @@ export class GalleryGridComponent
       }
     }
     if (groupIndex === -1) {
-      this.router.navigate([], {
-        queryParams: this.queryService.getParams(),
-      });
+      this.router.navigate([], {queryParams: this.queryService.getParams()});
       return;
     }
     // Make sure that at leas one more row is rendered

--- a/src/frontend/app/ui/gallery/grid/grid.gallery.component.ts
+++ b/src/frontend/app/ui/gallery/grid/grid.gallery.component.ts
@@ -193,6 +193,7 @@ export class GalleryGridComponent
   photoClicked(media: MediaDTO): void {
     this.router.navigate([], {
       queryParams: this.queryService.getParams({media}),
+      replaceUrl: true,
     });
   }
 
@@ -400,7 +401,10 @@ export class GalleryGridComponent
       }
     }
     if (groupIndex === -1) {
-      this.router.navigate([], {queryParams: this.queryService.getParams()});
+      this.router.navigate([], {
+        queryParams: this.queryService.getParams(),
+        replaceUrl: true,
+      });
       return;
     }
     // Make sure that at leas one more row is rendered

--- a/src/frontend/app/ui/gallery/lightbox/lightbox.gallery.component.ts
+++ b/src/frontend/app/ui/gallery/lightbox/lightbox.gallery.component.ts
@@ -442,6 +442,7 @@ export class GalleryLightboxComponent implements OnDestroy, OnInit {
         queryParams: this.queryService.getParams(
           {media: this.gridPhotoQL.get(photoIndex).gridMedia.media, playing: this.slideShowRunning}
         ),
+        replaceUrl: true,
       })
       .then(() => {
         this.piTitleService.setMediaTitle(this.gridPhotoQL.get(photoIndex).gridMedia);


### PR DESCRIPTION
Resolves https://github.com/bpatrik/pigallery2/issues/819.
Sets a parameter on gallery navigation to replace the history state on every navigation change. Thus when navigating phots in the lightbox each photo view acts as the most recent navigation state and when hitting back, it returns to the album.