### PR TITLE
Enable TLS 1.3 in nginx.conf

### DIFF
--- a/docker/docker-compose/default/nginx.conf
+++ b/docker/docker-compose/default/nginx.conf
@@ -21,7 +21,7 @@ http {
 	# SSL Settings
 	##
 
-	ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # Dropping SSLv3, ref: POODLE
+	ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3; # Dropping SSLv3, ref: POODLE
 	ssl_prefer_server_ciphers on;
 
 	##


### PR DESCRIPTION
TLS 1.3 has been supported in nginx since 2018. This change brings nginx.conf to parity with what nginx recommends by default.