### PR TITLE
Provide more reasonable quality for webp video thumbnails

### DIFF
--- a/src/backend/model/fileaccess/PhotoWorker.ts
+++ b/src/backend/model/fileaccess/PhotoWorker.ts
@@ -103,7 +103,7 @@ export class VideoRendererFactory {
             .on('error', (e): void => {
               reject('[FFmpeg] ' + e.toString() + ' executed: ' + executedCmd);
             })
-            .outputOptions(['-qscale:v 4']);
+            .outputOptions(['-qscale:v 50']);
           if (input.makeSquare === false) {
             const newSize =
               width < height


### PR DESCRIPTION
qscale=4 provides bad quality for webp video thumbnails. qscale=50 creates better results and has a comparable size to image thumbnails.