### PR TITLE
Fix video download

### DIFF
--- a/src/backend/routes/GalleryRouter.ts
+++ b/src/backend/routes/GalleryRouter.ts
@@ -202,7 +202,7 @@ export class GalleryRouter {
     app.get(
         Config.Server.apiPath + '/gallery/content/:mediaPath(*.(' +
         SupportedFormats.Videos.join('|') +
-        '))/:size?',
+        '))/:size',
         // common part
         AuthenticationMWs.authenticate,
         AuthenticationMWs.normalizePathParam('mediaPath'),


### PR DESCRIPTION
Fix https://github.com/bpatrik/pigallery2/issues/941 "cannot download videos".

Avoid clashes between `addGetVideo` and `addGetVideoThumbnail` by fixing API endpoint signature. (Compare to `addGetImage` and `addGetResizedPhoto` which work as expected)
Otherwise, `addGetVideoThumbnail` intercepts requests to `.../gallery/content/video.mp4` and returns a thumbnail pic instead of the original video file.
