### PR TITLE
fix #988 sort numerically

### DIFF
--- a/src/frontend/app/ui/gallery/blog/blog.service.ts
+++ b/src/frontend/app/ui/gallery/blog/blog.service.ts
@@ -56,7 +56,7 @@ export class BlogService {
       }];
     }
 
-    dates.sort();
+    dates.sort((a, b) => a - b);
 
     const splitterRgx = new RegExp(/^\s*<!--\s*@pg-date:?\s*\d{4}-\d{1,2}-\d{1,2}\s*-->/, 'gim');
     const dateRgx = new RegExp(/\d{4}-\d{1,2}-\d{1,2}/);


### PR DESCRIPTION
As written in https://github.com/bpatrik/pigallery2/issues/988 blog notes of older photos (before 1970-04-27) are wrongly sorted shown.
The reason becomes obvious when looking at the numerical presentation of the dates:

- 1970-04-26 =  9936000000
- 1970-04-27 = 10022400000
- 1970-11-01 = 26265600000

I first suspected the culprit in the “10-digit rule” which is to distinguish seconds from milliseconds when normalizing timestamps. In many systems, a timestamp value less than 10^10 is assumed to be in seconds, whereas a larger value is assumed to be in milliseconds. But this assumption did not hold true since PiGallery2 uses dates properly transformed to milliseconds. 
The reason is even simpler, but well hidden in the [blog.service.ts](https://github.com/bpatrik/pigallery2/blob/master/src/frontend/app/ui/gallery/blog/blog.service.ts#L59). 
The line `dates.sort();` does not look suspicious at all unless you know that the JavaScript `sort()` method sorts values **lexicographically** (as strings) rather than **numerically** even if `dates` is an array of type `number`. This leads to incorrect sorting of timestamps. The solution is to provide a numeric comparison function like `sort((a, b) => a - b)` to ensure proper chronological sorting, which this PR has implemented.