### PR TITLE
Fixbuild

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
       with:
         start: npm run start-e2e-server
       # after the test run completes store screenshots
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: failure() # Store screenshots only on failures
       with:
          name: cypress-screenshots

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,7 +141,7 @@ jobs:
           file: docker/${{ matrix.container }}/Dockerfile.build
           platforms: ${{ matrix.platforms }}
           push: true
-          tags: bpatrik/pigallery2:experimental-${{ matrix.container }}
+          tags: ${{ secrets.REGISTRY_NAMESPACE }}/pigallery2:experimental-${{ matrix.container }}
       - name: Push edge on new master commit
         # github.ref:  branches the format is refs/heads/<branch_name>  PRs and Tags are different
         if: ${{github.ref == 'refs/heads/master' }}
@@ -151,7 +151,7 @@ jobs:
           file: docker/${{ matrix.container }}/Dockerfile.build
           platforms: ${{ matrix.platforms }}
           push: true
-          tags: bpatrik/pigallery2:edge-${{ matrix.container }}
+          tags: ${{ secrets.REGISTRY_NAMESPACE }}/pigallery2:edge-${{ matrix.container }}
       - name: Push release on new Tag
         if: ${{ startsWith(github.ref_type , 'tag') &&  !github.event.issue.pull_request &&  matrix.container != 'debian-bookworm'}}
         uses: docker/build-push-action@v5
@@ -161,9 +161,9 @@ jobs:
           platforms: ${{ matrix.platforms }}
           push: true
           tags: |
-            bpatrik/pigallery2:edge-${{ matrix.container }}
-            bpatrik/pigallery2:${{ github.ref_name }}-${{ matrix.container }}
-            bpatrik/pigallery2:latest-${{ matrix.container }}
+            ${{ secrets.REGISTRY_NAMESPACE }}/pigallery2:edge-${{ matrix.container }}
+            ${{ secrets.REGISTRY_NAMESPACE }}/pigallery2:${{ github.ref_name }}-${{ matrix.container }}
+            ${{ secrets.REGISTRY_NAMESPACE }}/pigallery2:latest-${{ matrix.container }}
       - name: Push latest on new Tag
         if: ${{ startsWith(github.ref_type, 'tag') &&  !github.event.issue.pull_request &&  matrix.container == 'debian-bookworm'}}
         uses: docker/build-push-action@v5
@@ -173,8 +173,8 @@ jobs:
           platforms: ${{ matrix.platforms }}
           push: true
           tags: |
-            bpatrik/pigallery2:edge-${{ matrix.container }}
-            bpatrik/pigallery2:${{ github.ref_name }}-${{ matrix.container }}
-            bpatrik/pigallery2:latest-${{ matrix.container }}
-            bpatrik/pigallery2:${{ github.ref_name }}
-            bpatrik/pigallery2:latest
+            ${{ secrets.REGISTRY_NAMESPACE }}/pigallery2:edge-${{ matrix.container }}
+            ${{ secrets.REGISTRY_NAMESPACE }}/pigallery2:${{ github.ref_name }}-${{ matrix.container }}
+            ${{ secrets.REGISTRY_NAMESPACE }}/pigallery2:latest-${{ matrix.container }}
+            ${{ secrets.REGISTRY_NAMESPACE }}/pigallery2:${{ github.ref_name }}
+            ${{ secrets.REGISTRY_NAMESPACE }}/pigallery2:latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ on:
       - '**'
     tags:
       - '*.*'
+  workflow_dispatch:
+
 
 jobs:
   test:

--- a/docker/alpine/Dockerfile.build
+++ b/docker/alpine/Dockerfile.build
@@ -2,8 +2,8 @@
 #-----------------------------------------
 FROM node:18-alpine3.17 AS builder
 RUN apk add --no-cache --repository https://alpine.global.ssl.fastly.net/alpine/v3.17/community/ \
-  python3 build-base sqlite-dev sqlite-libs imagemagick-dev libraw-dev vips-dev vips-heif vips-magick fftw-dev gcc g++ make libc6-compat && ln -snf /usr/bin/python3 /usr/bin/python && \
-  rm /var/cache/apk/*
+  python3 build-base sqlite-dev sqlite-libs imagemagick-dev libraw-dev vips-dev vips-heif vips-magick fftw-dev gcc g++ make libc6-compat && ln -snf /usr/bin/python3 /usr/bin/python
+
 COPY pigallery2-release /app
 WORKDIR /app
 RUN npm install --unsafe-perm  --fetch-timeout=90000
@@ -18,18 +18,17 @@ RUN mkdir -p /app/data/config && \
 FROM node:18-alpine3.17 AS main
 WORKDIR /app
 ENV NODE_ENV=production \
-    # overrides only the default value of the settings (the actualy value can be overwritten through config.json)
+    # overrides only the default value of the settings (the actual value can be overwritten through config.json)
     default-Database-dbFolder=/app/data/db \
     default-Media-folder=/app/data/images \
     default-Media-tempFolder=/app/data/tmp \
     default-Extensions-folder=/app/data/config/extensions \
-    # flagging dockerized environemnt
+    # flagging dockerized environment
     PI_DOCKER=true
 
 EXPOSE 80
 RUN apk add --no-cache --repository https://alpine.global.ssl.fastly.net/alpine/v3.17/community/ \
-    vips vips-cpp vips-heif vips-magick ffmpeg && \
-    rm /var/cache/apk/*
+    vips vips-cpp vips-heif vips-magick ffmpeg
 COPY --from=builder /app /app
 
 # Run build time diagnostics to make sure the app would work after build is finished
@@ -38,6 +37,6 @@ HEALTHCHECK --interval=40s --timeout=30s --retries=3 --start-period=60s \
   CMD wget --quiet --tries=1 --no-check-certificate --spider \
   http://127.0.0.1:80/heartbeat || exit 1
 
-# after a extensive job (like video converting), pigallery calls gc, to clean up everthing as fast as possible
+# after a extensive job (like video converting), pigallery calls gc, to clean up everything as fast as possible
 # Exec form entrypoint is need otherwise (using shell form) ENV variables are not properly passed down to the app
 ENTRYPOINT ["node", "./src/backend/index", "--expose-gc",  "--config-path=/app/data/config/config.json"]


### PR DESCRIPTION
The build failed due the deprecated `actions/upload-artifact@v3` which this PR fixes by replacing it by `actions/upload-artifact@v4`.
Moreover, to enable forked repositories to push the docker images to **their own** docker hub namespace, the namespace `bpatrik` is replaced by  `${{ secrets.REGISTRY_NAMESPACE }}`, so the users just need to add a github secret named `REGISTRY_NAMESPACE` with value of their docker hub namespace. It's not a secret per se but doing so aligns with the existing secrets `REGISTRY_USERNAME`and `REGISTRY_PASSWORD`.
I also added a `workflow_dispatch` trigger because it's handy to be able to run the workflow on demand and not just on commit.
Last but not least I removed the `rm /var/cache/apk/*` because first it may break the workflow if the github runner is still using the cache and secondly because it's not even needed since the option `--no-cache` is used.
