### PR TITLE
fix(heic): Bump image-size dependency to v2.0.2 

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "express": "4.18.2",
     "express-unless": "2.1.3",
     "fluent-ffmpeg": "2.1.2",
-    "image-size": "1.1.1",
+    "image-size": "2.0.2",
     "locale": "0.1.0",
     "node-geocoder": "4.2.0",
     "nodemailer": "6.9.4",


### PR DESCRIPTION

This pull request updates the `image-size` package in `package.json` to version 2.0.2, replacing the previous version 1.1.1. This change ensures HEIC tumbnails are shown with the correct aspect ratio, and fixes the 512x512 HEIC thumbnails issue.

Tested in local, building the alpine image.