### PR TITLE
[Logging] Add remote IP log context on authn failure

### DIFF
--- a/src/backend/middlewares/user/AuthenticationMWs.ts
+++ b/src/backend/middlewares/user/AuthenticationMWs.ts
@@ -160,7 +160,7 @@ export class AuthenticationMWs {
               sharing.password) &&
               !PasswordHelper.comparePassword(password, sharing.password))
       ) {
-        Logger.warn(LOG_TAG, 'Failed login with sharing:' + sharing.sharingKey + ', bad password');
+        Logger.warn(LOG_TAG, 'Failed login from IP `' + req.ip + '` with sharing:' + sharing.sharingKey + ', bad password');
         res.status(401);
         return next(new ErrorDTO(ErrorCodes.CREDENTIAL_NOT_FOUND));
       }
@@ -209,7 +209,7 @@ export class AuthenticationMWs {
         typeof req.body.loginCredential.username === 'undefined' ||
         typeof req.body.loginCredential.password === 'undefined'
     ) {
-      Logger.warn(LOG_TAG, 'Failed login no user or password provided');
+      Logger.warn(LOG_TAG, 'Failed login from IP `' + req.ip + '` no user or password provided');
       return next(
           new ErrorDTO(
               ErrorCodes.INPUT_ERROR,
@@ -234,7 +234,7 @@ export class AuthenticationMWs {
       }
       return next();
     } catch (err) {
-      Logger.warn(LOG_TAG, 'Failed login for user:' + req.body.loginCredential.username
+      Logger.warn(LOG_TAG, 'Failed login from IP `' + req.ip + '` for user:' + req.body.loginCredential.username
           + ', bad password');
       return next(
           new ErrorDTO(

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -117,6 +117,11 @@ export class Server {
     // Get PORT from environment and store in Express.
     this.app.set('port', Config.Server.port);
 
+    // Set express 'trust proxy' setting to extract Remote Client IP
+    // from optional reverse proxies trusted headers
+    // See https://expressjs.com/en/guide/behind-proxies.html
+    this.app.set('trust proxy', Server.getAppTrustProxyConfig());
+
     // Create HTTP server.
     this.server = _http.createServer(this.app);
 
@@ -194,6 +199,27 @@ export class Server {
   private onClose = () => {
     Logger.info(LOG_TAG, 'Closed http server');
   };
+
+  private static getAppTrustProxyConfig(): boolean | string | number {
+    const trustProxyValue = Config.Server.trustProxy;
+
+    switch (trustProxyValue) {
+      case "true":
+        return true;
+        break;
+
+      case "false":
+        return false;
+        break;
+
+      default:
+        if (/^\d+$/.test(trustProxyValue)) {
+          return Number(trustProxyValue);
+        }
+
+        return trustProxyValue;
+    }
+  }
 
   public Stop(): Promise<void> {
     return new Promise((resolve, reject) => {

--- a/src/common/config/private/PrivateConfig.ts
+++ b/src/common/config/private/PrivateConfig.ts
@@ -935,6 +935,16 @@ export class ServerServiceConfig extends ClientServiceConfig {
 
   @ConfigProperty({
     tags: {
+      name: $localize`Trust Proxy`,
+      priority: ConfigPriority.underTheHood,
+      githubIssue: 1014
+    },
+    description: $localize`Should the backend trust proxies to extract remote Client IP`,
+  })
+  trustProxy: string = "false";
+
+  @ConfigProperty({
+    tags: {
       name: $localize`Port`,
       priority: ConfigPriority.advanced,
       uiResetNeeded: {server: true},


### PR DESCRIPTION
Fixes #1014 

Add support for [express trust proxy](https://expressjs.com/en/guide/behind-proxies.html) and remote client IP in failed authentication logs.