### PR TITLE
Updated Dockerfile

### DIFF
--- a/docker/debian-trixie/selfcontained/Dockerfile
+++ b/docker/debian-trixie/selfcontained/Dockerfile
@@ -48,7 +48,7 @@ RUN apt-get update \
     fi \
     && apt-get clean -q -y \
     && rm -rf /var/lib/apt/lists/*
-COPY --from=builder /app /app
+COPY --from=builder /build/release /app
 
 # Run build time diagnostics to make sure the app would work after build is finished
 RUN ["node", "--expose-gc", "./src/backend/index", "--run-diagnostics", "--config-path=/app/diagnostics-config.json", "--Server-Log-level=silly"]


### PR DESCRIPTION
Changed builder path to correctly refer to `/build/release` instead of `/app` which doesn't exist. This has caused the selfcontained docker file build to [fail](https://github.com/bpatrik/pigallery2/issues/1102). 