### PR TITLE
Fix biased random sort by using Fisher-Yates shuffle

### DIFF
--- a/src/frontend/app/ui/gallery/navigator/sorting.service.ts
+++ b/src/frontend/app/ui/gallery/navigator/sorting.service.ts
@@ -173,18 +173,10 @@ export class GallerySortingService {
         break;
       case SortByTypes.Random:
         this.rndService.setSeed(media.length);
-        media.sort((a: PhotoDTO, b: PhotoDTO): number => {
-          if (a.name.toLowerCase() < b.name.toLowerCase()) {
-            return -1;
-          }
-          if (a.name.toLowerCase() > b.name.toLowerCase()) {
-            return 1;
-          }
-          return 0;
-        })
-          .sort((): number => {
-            return this.rndService.get() - 0.5;
-          });
+        for (let i = media.length - 1; i > 0; i--) {
+          const j = Math.floor(this.rndService.get() * (i + 1));
+          [media[i], media[j]] = [media[j], media[i]];
+        }
         break;
     }
     if (!sorting.ascending) {
@@ -273,19 +265,10 @@ export class GallerySortingService {
                             break;
                           case SortByTypes.Random:
                             this.rndService.setSeed(c.directories.length);
-                            c.directories
-                                .sort((a, b): number => {
-                                  if (a.name.toLowerCase() < b.name.toLowerCase()) {
-                                    return 1;
-                                  }
-                                  if (a.name.toLowerCase() > b.name.toLowerCase()) {
-                                    return -1;
-                                  }
-                                  return 0;
-                                })
-                                .sort((): number => {
-                                  return this.rndService.get() - 0.5;
-                                });
+                            for (let i = c.directories.length - 1; i > 0; i--) {
+                              const j = Math.floor(this.rndService.get() * (i + 1));
+                              [c.directories[i], c.directories[j]] = [c.directories[j], c.directories[i]];
+                            }
                             break;
                         }
 


### PR DESCRIPTION
## Summary

- The random sort option used `Array.sort()` with a random comparator, which is a [well-known antipattern](https://blog.codinghorror.com/the-danger-of-naivete/) that produces biased results — items tend to stay near their original (alphabetically sorted) position
- This is especially noticeable when filenames share a common prefix (e.g. `France - beach`, `France - city`, `Italy - beach`, `Italy - city`), as the alphabetical pre-sort clusters them and the biased shuffle preserves those clusters
- Replaced with [Fisher-Yates shuffle](https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle) for both media and directories, which guarantees a uniform random permutation
- The existing seeded PRNG is still used, so the shuffle remains deterministic within a page load

## Test plan

- [ ] Select random sorting on a gallery with many similarly-named files and verify items are well-mixed
- [ ] Verify the shuffle is stable within a page load (navigating away and back gives the same order)
- [ ] Verify directory random sorting also works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)