### PR TITLE
feat: add Exclude Filename List to help ignore hidden files

### DIFF
--- a/src/backend/model/fileaccess/DiskManager.ts
+++ b/src/backend/model/fileaccess/DiskManager.ts
@@ -58,6 +58,27 @@ export class DiskManager {
     return path.basename(dirPath);
   }
 
+  private static globToRegex(glob: string): RegExp {
+    const regexStr = '^' + glob
+      .replace(/[.+^${}()|[\]\\]/g, '\\$&') // escape regex special chars (except * and ?)
+      .replace(/\*/g, '.*')                   // * matches any number of any chars
+      .replace(/\?/g, '.') +                  // ? matches exactly one char
+      '$';
+    return new RegExp(regexStr, 'i');
+  }
+
+  public static excludeFile(filename: string): boolean {
+    if (Config.Indexing.excludeFilenameList.length === 0) {
+      return false;
+    }
+    for (const glob of Config.Indexing.excludeFilenameList) {
+      if (DiskManager.globToRegex(glob).test(filename)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   @ExtensionDecorator(e => e.gallery.DiskManager.excludeDir)
   public static async excludeDir(dir: {
     name: string,
@@ -203,6 +224,8 @@ export class DiskManager {
           );
           console.error(err);
         }
+      } else if (DiskManager.excludeFile(file)) {
+        continue;
       } else if (PhotoProcessing.isPhoto(fullFilePath)) {
         try {
           if (settings.noPhoto === true) {

--- a/src/common/config/private/PrivateConfig.ts
+++ b/src/common/config/private/PrivateConfig.ts
@@ -656,6 +656,19 @@ export class ServerIndexingConfig {
     description: $localize`Files that mark a folder to be excluded from indexing. Any folder that contains a file with this name will be excluded from indexing.`,
   })
   excludeFileList: string[] = [];
+  @ConfigProperty({
+    arrayType: 'string',
+    tags:
+      {
+        name: $localize`Exclude Filename List`,
+        priority: ConfigPriority.advanced,
+        uiResetNeeded: {server: true, db: true},
+        uiOptional: true,
+        hint: $localize`.*;*.rm`
+      } as TAGS,
+    description: $localize`Glob patterns to exclude individual media files from indexing. Supports '*' (any characters), '?' (single character) wildcards and ';' to separate multiple patterns. E.g.: '._*' excludes macOS resource fork files starting with '._'; '*.rm' excludes .rm files.`,
+  })
+  excludeFilenameList: string[] = [];
 }
 
 @SubConfigClass({softReadonly: true})

--- a/test/backend/unit/model/threading/DiskManagerWorker.spec.ts
+++ b/test/backend/unit/model/threading/DiskManagerWorker.spec.ts
@@ -7,6 +7,7 @@ import {DatabaseType} from '../../../../../src/common/config/private/PrivateConf
 import {DiskManager} from '../../../../../src/backend/model/fileaccess/DiskManager';
 
 declare const before: any;
+declare const afterEach: any;
 
 describe('DiskMangerWorker', () => {
   // loading default settings (this might have been changed by other tests)
@@ -18,6 +19,9 @@ describe('DiskMangerWorker', () => {
     Config.Extensions.enabled = false;
   });
 
+  afterEach(() => {
+    Config.Indexing.excludeFilenameList = [];
+  });
 
   it('should parse metadata', async () => {
     Config.Media.folder = path.join(__dirname, '/../../../assets');
@@ -31,5 +35,64 @@ describe('DiskMangerWorker', () => {
     const i = dir.media.findIndex(m => m.name === 'test image öüóőúéáű-.,.jpg');
     expect(Utils.clone(dir.media[i].name)).to.be.deep.equal('test image öüóőúéáű-.,.jpg');
     expect(Utils.clone(dir.media[i].metadata)).to.be.deep.equal(expected);
+  });
+
+  describe('excludeFilenameList', () => {
+    it('excludeFile should return false when list is empty', () => {
+      Config.Indexing.excludeFilenameList = [];
+      expect(DiskManager.excludeFile('._photo.jpg')).to.be.false;
+      expect(DiskManager.excludeFile('photo.jpg')).to.be.false;
+    });
+
+    it('excludeFile should exclude dot-files using glob pattern ".*"', () => {
+      Config.Indexing.excludeFilenameList = ['.*'];
+      expect(DiskManager.excludeFile('._photo.jpg')).to.be.true;
+      expect(DiskManager.excludeFile('.hidden.jpg')).to.be.true;
+      expect(DiskManager.excludeFile('photo.jpg')).to.be.false;
+      expect(DiskManager.excludeFile('normal_video.mp4')).to.be.false;
+    });
+
+    it('excludeFile should exclude files by extension using glob pattern "*.rm"', () => {
+      Config.Indexing.excludeFilenameList = ['*.rm'];
+      expect(DiskManager.excludeFile('video.rm')).to.be.true;
+      expect(DiskManager.excludeFile('VIDEO.RM')).to.be.true; // case insensitive
+      expect(DiskManager.excludeFile('video.mp4')).to.be.false;
+      expect(DiskManager.excludeFile('video.rm.bak')).to.be.false;
+    });
+
+    it('excludeFile should support multiple glob patterns', () => {
+      Config.Indexing.excludeFilenameList = ['.*', '*.rm'];
+      expect(DiskManager.excludeFile('._photo.jpg')).to.be.true;
+      expect(DiskManager.excludeFile('video.rm')).to.be.true;
+      expect(DiskManager.excludeFile('photo.jpg')).to.be.false;
+    });
+
+    it('excludeFile should support "?" wildcard for single character', () => {
+      Config.Indexing.excludeFilenameList = ['photo?.jpg'];
+      expect(DiskManager.excludeFile('photo1.jpg')).to.be.true;
+      expect(DiskManager.excludeFile('photoA.jpg')).to.be.true;
+      expect(DiskManager.excludeFile('photo.jpg')).to.be.false;
+      expect(DiskManager.excludeFile('photo12.jpg')).to.be.false;
+    });
+
+    it('scanDirectory should exclude files matching glob patterns in excludeFilenameList', async () => {
+      Config.Media.folder = path.join(__dirname, '/../../../assets');
+      ProjectPath.ImageFolder = path.join(__dirname, '/../../../assets');
+      Config.Indexing.excludeFilenameList = ['.*'];
+      const dir = await DiskManager.scanDirectory('/');
+      // All files starting with '.' should be excluded
+      const dotFiles = dir.media.filter(m => m.name.startsWith('.'));
+      expect(dotFiles).to.have.length(0);
+      // Non-dot files should still be present
+      expect(dir.media.length).to.be.greaterThan(0);
+    });
+
+    it('scanDirectory should include all files when excludeFilenameList is empty', async () => {
+      Config.Media.folder = path.join(__dirname, '/../../../assets');
+      ProjectPath.ImageFolder = path.join(__dirname, '/../../../assets');
+      Config.Indexing.excludeFilenameList = [];
+      const dir = await DiskManager.scanDirectory('/');
+      expect(dir.media.length).to.be.equals(18);
+    });
   });
 });


### PR DESCRIPTION
Hi, this is a quick PR to help filter hidden and system files. I think it addressed the following issues
- https://github.com/bpatrik/pigallery2/issues/803
- https://github.com/bpatrik/pigallery2/issues/661
- https://github.com/bpatrik/pigallery2/issues/929

The PR is mostly AI generated, but I have tested it with my collection and run the unit tests

-----------------------------------------------

## Summary

Adds a new **Exclude Filename List** setting in Indexing configuration that allows users to exclude individual media files from indexing and browsing using glob patterns.

## Motivation

Currently, PiGallery2 only supports excluding entire **folders** (\`excludeFolderList\`) or folders **containing a sentinel file** (\`excludeFileList\`). There is no way to exclude individual files by name pattern.

Common use cases:
- macOS resource fork files (\`._*\`) that get indexed as broken media
- Specific video formats (e.g. \`*.rm\`) not suitable for the gallery  
- Any filename pattern the user wants to hide

## Changes

### Config (\`src/common/config/private/PrivateConfig.ts\`)
New \`excludeFilenameList: string[]\` property in \`ServerIndexingConfig\` with:
- UI name: **Exclude Filename List**
- Hint: \`.*;*.rm\`  
- Description explaining glob wildcards (\`*\` = any chars, \`?\` = single char)
- Priority: advanced (shown in Advanced mode)

### Backend (\`src/backend/model/fileaccess/DiskManager.ts\`)
- \`private static globToRegex(glob)\`: converts glob pattern to case-insensitive \`RegExp\`
- \`static excludeFile(filename)\`: tests filename against all configured patterns
- Called in \`scanDirectory()\` before adding each photo/video/metafile to results

### Tests (\`test/backend/unit/model/threading/DiskManagerWorker.spec.ts\`)
7 new unit tests:
- Empty list → no exclusion
- \`.*\` glob excludes dot-files (\`._photo.jpg\`, \`.hidden.jpg\`)
- \`*.rm\` glob excludes by extension (case-insensitive)
- Multiple patterns work together
- \`?\` wildcard matches exactly one character
- \`scanDirectory()\` integration test with glob exclusion
- \`scanDirectory()\` baseline (empty list includes all files)

## Usage

In Admin → Indexing (Advanced mode), set **Exclude Filename List** to \`.*;*.rm\` to exclude macOS resource fork files and \`.rm\` videos.

Pattern syntax: glob (\`*\` = any chars, \`?\` = single char), \`;\`-separated, case-insensitive." 2>&1