### PR TITLE
Sub-folder sharing fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pigallery2",
-  "version": "3.5.2",
+  "version": "3.6.0-edge",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pigallery2",
-      "version": "3.5.2",
+      "version": "3.6.0-edge",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "0.5.16",

--- a/src/backend/middlewares/SharingMWs.ts
+++ b/src/backend/middlewares/SharingMWs.ts
@@ -47,9 +47,11 @@ export class SharingMWs {
         return next();
       }
       const sharingKey = req.params[QueryParams.gallery.sharingKey_params];
-
-      req.resultPipe =
-        {sharingKey: (await ObjectManagers.getInstance().SharingManager.findOne(sharingKey)).sharingKey} as SharingDTOKey;
+      const sharing = await ObjectManagers.getInstance().SharingManager.findOne(sharingKey);
+      req.resultPipe = {
+        sharingKey: sharing.sharingKey,
+        passwordProtected: !!(sharing.password || Config.Sharing.passwordRequired),
+      } as SharingDTOKey;
       return next();
     } catch (err) {
       return next(

--- a/src/backend/middlewares/user/AuthenticationMWs.ts
+++ b/src/backend/middlewares/user/AuthenticationMWs.ts
@@ -9,6 +9,7 @@ import {QueryParams} from '../../../common/QueryParams';
 import * as path from 'path';
 import {Logger} from '../../Logger';
 import {ContextUser} from '../../model/SessionContext';
+import {ANDSearchQuery, SearchQueryDTO, SearchQueryTypes, TextSearch, TextSearchQueryMatchTypes} from '../../../common/entities/SearchQueryDTO';
 
 const LOG_TAG = 'AuthenticationMWs';
 
@@ -296,6 +297,71 @@ export class AuthenticationMWs {
   public static logout(req: Request, res: Response, next: NextFunction): void {
     delete req.session.context;
     return next();
+  }
+
+  /**
+   * Canonical form for directory path comparison:
+   * - backslashes → forward slashes
+   * - trailing slashes stripped
+   * - '.' → '' (Utils.concatUrls returns '.' for the gallery root; normalise to empty string)
+   */
+  private static normalizeDirPath(p: string): string {
+    const fwd = p.replace(/\\/g, '/');
+    let end = fwd.length;
+    while (end > 0 && fwd[end - 1] === '/') end--;
+    const s = fwd.slice(0, end);
+    return s === '.' ? '' : s;
+  }
+
+  /**
+   * Middleware: allows LimitedGuest (sharing) users through only when the requested
+   * directory is the share root or a descendant of it. All other roles pass unconditionally.
+   */
+  public static authoriseSharingDirectory(req: Request, res: Response, next: NextFunction): void {
+    if (req.session?.context?.user?.role !== UserRoles.LimitedGuest) {
+      return next();
+    }
+    const allowQuery = req.session.context.user.allowQuery;
+    if (!allowQuery) {
+      return next();
+    }
+    const requestedDir = AuthenticationMWs.normalizeDirPath(req.params['directory'] || '');
+    if (AuthenticationMWs.isDirInShareScope(requestedDir, allowQuery)) {
+      return next();
+    }
+    res.status(401);
+    return next(new ErrorDTO(ErrorCodes.NOT_AUTHORISED));
+  }
+
+  /**
+   * Returns true when `dir` is within the directory scope of a share's allowQuery.
+   *
+   * - Exact-match directory share: dir must equal or be a descendant of the share root.
+   * - AND query: the top-level list must contain an exact-match directory clause; if none
+   *   is found the function fails closed (false) rather than granting access silently.
+   * - Non-directory shares (date, person, etc.): any directory is permitted here because
+   *   the DB-layer projectionQuery already restricts which media rows are returned.
+   */
+  private static isDirInShareScope(dir: string, query: SearchQueryDTO): boolean {
+    if (
+      query.type === SearchQueryTypes.directory &&
+      (query as TextSearch).matchType === TextSearchQueryMatchTypes.exact_match
+    ) {
+      const shareRoot = AuthenticationMWs.normalizeDirPath((query as TextSearch).value);
+      // Empty shareRoot means the gallery root — every directory is in scope.
+      if (shareRoot === '') return true;
+      return dir === shareRoot || dir.startsWith(shareRoot + '/');
+    }
+    if (query.type === SearchQueryTypes.AND) {
+      const dirClause = (query as ANDSearchQuery).list.find(
+        q => q.type === SearchQueryTypes.directory &&
+             (q as TextSearch).matchType === TextSearchQueryMatchTypes.exact_match
+      );
+      // Fail closed: an AND query with no recognisable directory clause is not granted access.
+      return dirClause ? AuthenticationMWs.isDirInShareScope(dir, dirClause) : false;
+    }
+    // Non-directory shares: projectionQuery enforces content scope at the DB layer.
+    return true;
   }
 
   private static async getSharingUser(req: Request): Promise<ContextUser> {

--- a/src/backend/model/database/SearchManager.ts
+++ b/src/backend/model/database/SearchManager.ts
@@ -481,7 +481,8 @@ export class SearchManager {
 
   public async prepareAndBuildWhereQuery(
     queryIN: SearchQueryDTO, directoryOnly = false,
-    aliases: { [key: string]: string } = {}): Promise<Brackets> {
+    aliases: { [key: string]: string } = {},
+    recursiveDir = false): Promise<Brackets> {
     let query = await this.prepareQuery(queryIN);
     if (directoryOnly) {
       query = this.filterDirectoryQuery(query);
@@ -489,7 +490,7 @@ export class SearchManager {
         return null;
       }
     }
-    return this.buildWhereQuery(query, directoryOnly, aliases);
+    return this.buildWhereQuery(query, directoryOnly, aliases, recursiveDir);
   }
 
   public async prepareQuery(queryIN: SearchQueryDTO): Promise<SearchQueryDTO> {
@@ -509,14 +510,15 @@ export class SearchManager {
   public buildWhereQuery(
     query: SearchQueryDTO,
     directoryOnly = false,
-    aliases: { [key: string]: string } = {}
+    aliases: { [key: string]: string } = {},
+    recursiveDir = false
   ): Brackets {
     const queryId = (query as SearchQueryDTOWithID).queryId;
     switch (query.type) {
       case SearchQueryTypes.AND:
         return new Brackets((q): unknown => {
           (query as ANDSearchQuery).list.forEach((sq) => {
-              q.andWhere(this.buildWhereQuery(sq, directoryOnly));
+              q.andWhere(this.buildWhereQuery(sq, directoryOnly, aliases, recursiveDir));
             }
           );
           return q;
@@ -524,7 +526,7 @@ export class SearchManager {
       case SearchQueryTypes.OR:
         return new Brackets((q): unknown => {
           (query as ANDSearchQuery).list.forEach((sq) => {
-              q.orWhere(this.buildWhereQuery(sq, directoryOnly));
+              q.orWhere(this.buildWhereQuery(sq, directoryOnly, aliases, recursiveDir));
             }
           );
           return q;
@@ -968,6 +970,19 @@ export class SearchManager {
             return dq;
           })
         );
+        // When building projection queries for sharing, also allow subdirectories recursively
+        if (
+          recursiveDir &&
+          query.type === SearchQueryTypes.directory &&
+          (query as TextSearch).matchType === TextSearchQueryMatchTypes.exact_match
+        ) {
+          const normalizedDirPath = dirPathStr.endsWith('/') ? dirPathStr : dirPathStr + '/';
+          textParam['subDirPath' + queryId] = normalizedDirPath + '%';
+          q[whereFN](
+            `${alias}.path ${LIKE} :subDirPath${queryId} COLLATE ` + SQL_COLLATE,
+            textParam
+          );
+        }
       }
 
       if (

--- a/src/backend/model/database/SearchManager.ts
+++ b/src/backend/model/database/SearchManager.ts
@@ -481,7 +481,8 @@ export class SearchManager {
 
   public async prepareAndBuildWhereQuery(
     queryIN: SearchQueryDTO, directoryOnly = false,
-    aliases: { [key: string]: string } = {}): Promise<Brackets> {
+    aliases: { [key: string]: string } = {},
+    recursiveDir = false): Promise<Brackets> {
     let query = await this.prepareQuery(queryIN);
     if (directoryOnly) {
       query = this.filterDirectoryQuery(query);
@@ -489,7 +490,7 @@ export class SearchManager {
         return null;
       }
     }
-    return this.buildWhereQuery(query, directoryOnly, aliases);
+    return this.buildWhereQuery(query, directoryOnly, aliases, recursiveDir);
   }
 
   public async prepareQuery(queryIN: SearchQueryDTO): Promise<SearchQueryDTO> {
@@ -509,14 +510,15 @@ export class SearchManager {
   public buildWhereQuery(
     query: SearchQueryDTO,
     directoryOnly = false,
-    aliases: { [key: string]: string } = {}
+    aliases: { [key: string]: string } = {},
+    recursiveDir = false
   ): Brackets {
     const queryId = (query as SearchQueryDTOWithID).queryId;
     switch (query.type) {
       case SearchQueryTypes.AND:
         return new Brackets((q): unknown => {
           (query as ANDSearchQuery).list.forEach((sq) => {
-              q.andWhere(this.buildWhereQuery(sq, directoryOnly));
+              q.andWhere(this.buildWhereQuery(sq, directoryOnly, aliases, recursiveDir));
             }
           );
           return q;
@@ -524,7 +526,7 @@ export class SearchManager {
       case SearchQueryTypes.OR:
         return new Brackets((q): unknown => {
           (query as ANDSearchQuery).list.forEach((sq) => {
-              q.orWhere(this.buildWhereQuery(sq, directoryOnly));
+              q.orWhere(this.buildWhereQuery(sq, directoryOnly, aliases, recursiveDir));
             }
           );
           return q;
@@ -968,6 +970,19 @@ export class SearchManager {
             return dq;
           })
         );
+        // For sharing projection queries, also match subdirectories recursively
+        if (
+          recursiveDir &&
+          query.type === SearchQueryTypes.directory &&
+          (query as TextSearch).matchType === TextSearchQueryMatchTypes.exact_match
+        ) {
+          const normalizedDirPath = dirPathStr.endsWith('/') ? dirPathStr : dirPathStr + '/';
+          textParam['subDirPath' + queryId] = normalizedDirPath + '%';
+          q[whereFN](
+            `${alias}.path ${LIKE} :subDirPath${queryId} COLLATE ` + SQL_COLLATE,
+            textParam
+          );
+        }
       }
 
       if (

--- a/src/backend/model/database/SessionManager.ts
+++ b/src/backend/model/database/SessionManager.ts
@@ -41,10 +41,10 @@ export class SessionManager {
 
     if (finalQuery) {
       // Build the Brackets-based query
-      context.projectionQuery = await ObjectManagers.getInstance().SearchManager.prepareAndBuildWhereQuery(finalQuery);
+      context.projectionQuery = await ObjectManagers.getInstance().SearchManager.prepareAndBuildWhereQuery(finalQuery, false, {}, true);
       context.hasDirectoryProjection = ObjectManagers.getInstance().SearchManager.hasDirectoryQuery(finalQuery);
       if (context.hasDirectoryProjection) {
-        context.projectionQueryForSubDir = await ObjectManagers.getInstance().SearchManager.prepareAndBuildWhereQuery(finalQuery, true, {directory: 'directories'});
+        context.projectionQueryForSubDir = await ObjectManagers.getInstance().SearchManager.prepareAndBuildWhereQuery(finalQuery, true, {directory: 'directories'}, true);
       }
       context.user.projectionKey = this.createProjectionKey(finalQuery);
       if (SearchQueryUtils.isQueryEmpty(finalQuery)) {

--- a/src/backend/routes/GalleryRouter.ts
+++ b/src/backend/routes/GalleryRouter.ts
@@ -35,7 +35,7 @@ export class GalleryRouter {
       [Config.Server.apiPath + '/gallery/content/:directory(*)', Config.Server.apiPath + '/gallery/', Config.Server.apiPath + '/gallery//'],
       // common part
       AuthenticationMWs.authenticate,
-      AuthenticationMWs.authorise(UserRoles.Guest), //sharing user can only go through search. They can't just wander through the whole gallery
+      AuthenticationMWs.authorise(UserRoles.LimitedGuest), // projectionQuery on sharing sessions already limits visible content
       AuthenticationMWs.normalizePathParam('directory'),
       VersionMWs.injectGalleryVersion,
 

--- a/src/backend/routes/GalleryRouter.ts
+++ b/src/backend/routes/GalleryRouter.ts
@@ -35,8 +35,9 @@ export class GalleryRouter {
       [Config.Server.apiPath + '/gallery/content/:directory(*)', Config.Server.apiPath + '/gallery/', Config.Server.apiPath + '/gallery//'],
       // common part
       AuthenticationMWs.authenticate,
-      AuthenticationMWs.authorise(UserRoles.Guest), //sharing user can only go through search. They can't just wander through the whole gallery
+      AuthenticationMWs.authorise(UserRoles.LimitedGuest),
       AuthenticationMWs.normalizePathParam('directory'),
+      AuthenticationMWs.authoriseSharingDirectory, // LimitedGuest: scope-checks the requested directory against the share root
       VersionMWs.injectGalleryVersion,
 
       // specific part
@@ -51,7 +52,7 @@ export class GalleryRouter {
   protected static addDirectoryZip(app: Express): void {
     app.get(
       [Config.Server.apiPath + '/gallery/zip/:searchQueryDTO(*)'],
-      // common part
+      // LimitedGuest allowed; content is scoped to the share by the session projectionQuery
       AuthenticationMWs.authenticate,
       AuthenticationMWs.authorise(UserRoles.LimitedGuest),
 
@@ -162,7 +163,7 @@ export class GalleryRouter {
   protected static addRandom(app: Express): void {
     app.get(
       [Config.Server.apiPath + '/gallery/random/:searchQueryDTO'],
-      // common part
+      // LimitedGuest allowed; content is scoped to the share by the session projectionQuery
       AuthenticationMWs.authenticate,
       AuthenticationMWs.authorise(UserRoles.LimitedGuest),
       VersionMWs.injectGalleryVersion,
@@ -256,7 +257,7 @@ export class GalleryRouter {
   protected static addSearch(app: Express): void {
     app.get(
       Config.Server.apiPath + '/search/:searchQueryDTO(*)',
-      // common part
+      // LimitedGuest allowed; content is scoped to the share by the session projectionQuery
       AuthenticationMWs.authenticate,
       AuthenticationMWs.authorise(UserRoles.LimitedGuest),
       VersionMWs.injectGalleryVersion,
@@ -274,7 +275,7 @@ export class GalleryRouter {
   protected static addAutoComplete(app: Express): void {
     app.get(
       Config.Server.apiPath + '/autocomplete/:value(*)',
-      // common part
+      // LimitedGuest allowed; content is scoped to the share by the session projectionQuery
       AuthenticationMWs.authenticate,
       AuthenticationMWs.authorise(UserRoles.LimitedGuest),
       VersionMWs.injectGalleryVersion,

--- a/src/backend/routes/SharingRouter.ts
+++ b/src/backend/routes/SharingRouter.ts
@@ -41,7 +41,7 @@ export class SharingRouter {
       // its a public path
       SharingMWs.getSharingKey,
       ServerTimingMWs.addServerTiming,
-      RenderingMWs.renderSharing
+      RenderingMWs.renderResult
     );
   }
 

--- a/src/common/entities/SharingDTO.ts
+++ b/src/common/entities/SharingDTO.ts
@@ -3,6 +3,7 @@ import {SearchQueryDTO} from './SearchQueryDTO';
 
 export interface SharingDTOKey {
   sharingKey: string;
+  passwordProtected?: boolean;
 }
 
 export interface BaseSharingDTO extends SharingDTOKey {

--- a/src/frontend/app/model/navigation.service.ts
+++ b/src/frontend/app/model/navigation.service.ts
@@ -4,7 +4,6 @@ import {IsActiveMatchOptions, Router} from '@angular/router';
 import {ShareService} from '../ui/gallery/share.service';
 import {Config} from '../../../common/config/public/Config';
 import {NavigationLinkTypes} from '../../../common/config/public/ClientConfig';
-import {firstValueFrom} from 'rxjs';
 
 @Injectable()
 export class NavigationService {
@@ -31,7 +30,7 @@ export class NavigationService {
   public async toLogin(): Promise<boolean> {
     await this.shareService.wait();
     if (this.shareService.isSharing()) {
-      if ((await firstValueFrom(this.shareService.currentSharing)).passwordProtected === true) {
+      if (this.shareService.sharingPasswordProtected === true) {
         return this.router.navigate(['shareLogin'], {
           queryParams: {sk: this.shareService.getSharingKey()},
         });

--- a/src/frontend/app/model/navigation.service.ts
+++ b/src/frontend/app/model/navigation.service.ts
@@ -4,8 +4,6 @@ import {IsActiveMatchOptions, Router} from '@angular/router';
 import {ShareService} from '../ui/gallery/share.service';
 import {Config} from '../../../common/config/public/Config';
 import {NavigationLinkTypes} from '../../../common/config/public/ClientConfig';
-import {firstValueFrom} from 'rxjs';
-
 @Injectable()
 export class NavigationService {
   constructor(private router: Router, private shareService: ShareService) {
@@ -31,7 +29,8 @@ export class NavigationService {
   public async toLogin(): Promise<boolean> {
     await this.shareService.wait();
     if (this.shareService.isSharing()) {
-      if ((await firstValueFrom(this.shareService.currentSharing)).passwordProtected === true) {
+      // sharingPasswordProtected is set synchronously from the /key endpoint before ReadyPR resolves
+      if (this.shareService.sharingPasswordProtected === true) {
         return this.router.navigate(['shareLogin'], {
           queryParams: {sk: this.shareService.getSharingKey()},
         });

--- a/src/frontend/app/model/network/authentication.service.ts
+++ b/src/frontend/app/model/network/authentication.service.ts
@@ -19,6 +19,7 @@ declare module ServerInject {
 @Injectable({providedIn: 'root'})
 export class AuthenticationService {
   public readonly user: BehaviorSubject<UserDTO>;
+  private sessionUserPromise: Promise<void> | null = null;
 
   constructor(
     private userService: UserService,
@@ -39,7 +40,8 @@ export class AuthenticationService {
       ) {
         this.user.next(ServerInject.user);
       }
-      this.getSessionUser().catch(console.error);
+      this.sessionUserPromise = this.getSessionUser();
+      this.sessionUserPromise.catch(console.error);
     } else {
       if (Config.Users.authenticationRequired === false) {
         this.user.next({
@@ -99,14 +101,19 @@ export class AuthenticationService {
   public async logout(): Promise<void> {
     await this.userService.logout();
     this.user.next(null);
-    // even on logout try to get sharing user if it's a sharing
     await this.shareService.wait();
-    if(this.shareService.isSharing()){
+    // Restore a non-password-protected sharing session after logout.
+    // Skip for password-protected shares — getSessionUser always returns 401 until re-auth.
+    if (this.shareService.isSharing() && this.shareService.sharingPasswordProtected !== true) {
       await this.getSessionUser();
     }
   }
 
-  private async getSessionUser(): Promise<void> {
+  public waitForSessionUser(): Promise<void> {
+    return this.sessionUserPromise ?? Promise.resolve();
+  }
+
+  public async getSessionUser(): Promise<void> {
     try {
       this.user.next(await this.userService.getSessionUser());
     } catch (error) {

--- a/src/frontend/app/model/network/authentication.service.ts
+++ b/src/frontend/app/model/network/authentication.service.ts
@@ -19,6 +19,7 @@ declare module ServerInject {
 @Injectable({providedIn: 'root'})
 export class AuthenticationService {
   public readonly user: BehaviorSubject<UserDTO>;
+  private sessionUserPromise: Promise<void> | null = null;
 
   constructor(
     private userService: UserService,
@@ -39,7 +40,8 @@ export class AuthenticationService {
       ) {
         this.user.next(ServerInject.user);
       }
-      this.getSessionUser().catch(console.error);
+      this.sessionUserPromise = this.getSessionUser();
+      this.sessionUserPromise.catch(console.error);
     } else {
       if (Config.Users.authenticationRequired === false) {
         this.user.next({
@@ -99,14 +101,19 @@ export class AuthenticationService {
   public async logout(): Promise<void> {
     await this.userService.logout();
     this.user.next(null);
-    // even on logout try to get sharing user if it's a sharing
+    // Restore a non-password-protected sharing session after logout.
+    // Skip for password-protected shares — getSessionUser always returns 401 until re-auth.
     await this.shareService.wait();
-    if(this.shareService.isSharing()){
+    if (this.shareService.isSharing() && this.shareService.sharingPasswordProtected !== true) {
       await this.getSessionUser();
     }
   }
 
-  private async getSessionUser(): Promise<void> {
+  public waitForSessionUser(): Promise<void> {
+    return this.sessionUserPromise ?? Promise.resolve();
+  }
+
+  public async getSessionUser(): Promise<void> {
     try {
       this.user.next(await this.userService.getSessionUser());
     } catch (error) {

--- a/src/frontend/app/model/network/helper/auth.guard.ts
+++ b/src/frontend/app/model/network/helper/auth.guard.ts
@@ -2,21 +2,35 @@ import {Injectable} from '@angular/core';
 import {ActivatedRouteSnapshot, CanActivate, RouterStateSnapshot} from '@angular/router';
 import {AuthenticationService} from '../authentication.service';
 import {NavigationService} from '../../navigation.service';
+import {ShareService} from '../../../ui/gallery/share.service';
 
 @Injectable({providedIn: 'root'})
-export class AuthGuard implements CanActivate{
+export class AuthGuard implements CanActivate {
   constructor(
-      private authenticationService: AuthenticationService,
-      private navigationService: NavigationService
+    private authenticationService: AuthenticationService,
+    private navigationService: NavigationService,
+    private shareService: ShareService,
   ) {
   }
 
-  canActivate(
-      route: ActivatedRouteSnapshot,
-      state: RouterStateSnapshot
-  ): boolean {
-    if (this.authenticationService.isAuthenticated() === true) {
+  async canActivate(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): Promise<boolean> {
+    // Wait for session cookie restoration (async HTTP call started in constructor)
+    await this.authenticationService.waitForSessionUser();
+
+    if (this.authenticationService.isAuthenticated()) {
       return true;
+    }
+
+    // For no-password shares, try backend auto-authentication via the sharing key
+    await this.shareService.wait();
+    if (this.shareService.isSharing() && this.shareService.sharingPasswordProtected === false) {
+      await this.authenticationService.getSessionUser();
+      if (this.authenticationService.isAuthenticated()) {
+        return true;
+      }
     }
 
     this.navigationService.toLogin().catch(console.error);

--- a/src/frontend/app/model/network/helper/error.interceptor.ts
+++ b/src/frontend/app/model/network/helper/error.interceptor.ts
@@ -20,8 +20,13 @@ export class ErrorInterceptor implements HttpInterceptor {
     return next.handle(request).pipe(
       catchError((err) => {
         if (err.status === 401) {
-          // auto logout if 401 response returned from server
-          this.authenticationService.logout();
+          if (this.authenticationService.user.value !== null) {
+            // Logged-in user got a 401 — log them out
+            this.authenticationService.logout();
+          } else {
+            // Already unauthenticated — just navigate to login to avoid a logout→getSessionUser→401 loop
+            this.navigationService.toLogin();
+          }
         }
         if (err.status === 500 && err.error.error.code === ErrorCodes.INTERNAL) {
           // Unknown server error

--- a/src/frontend/app/model/network/helper/error.interceptor.ts
+++ b/src/frontend/app/model/network/helper/error.interceptor.ts
@@ -20,8 +20,13 @@ export class ErrorInterceptor implements HttpInterceptor {
     return next.handle(request).pipe(
       catchError((err) => {
         if (err.status === 401) {
-          // auto logout if 401 response returned from server
-          this.authenticationService.logout();
+          if (this.authenticationService.user.value !== null) {
+            // Logged-in user got a 401 — clear session
+            this.authenticationService.logout();
+          } else {
+            // Already unauthenticated — navigate to login directly to avoid a logout→401 loop
+            this.navigationService.toLogin();
+          }
         }
         if (err.status === 500 && err.error.error.code === ErrorCodes.INTERNAL) {
           // Unknown server error

--- a/src/frontend/app/ui/gallery/gallery.component.spec.ts
+++ b/src/frontend/app/ui/gallery/gallery.component.spec.ts
@@ -52,11 +52,12 @@ class MockContentService {
 }
 
 class MockAuthenticationService {
-  user = new BehaviorSubject(null); // Add this line
+  user = new BehaviorSubject(null);
   isAuthenticated = jasmine.createSpy('isAuthenticated').and.returnValue(true);
   canSearch = jasmine.createSpy('canSearch').and.returnValue(true);
   isAuthorized = jasmine.createSpy('isAuthorized').and.returnValue(true);
-  logout = jasmine.createSpy('logout'); // Also add logout method if needed
+  logout = jasmine.createSpy('logout');
+  waitForSessionUser = jasmine.createSpy('waitForSessionUser').and.returnValue(Promise.resolve());
 }
 
 class MockShareService {

--- a/src/frontend/app/ui/gallery/gallery.component.ts
+++ b/src/frontend/app/ui/gallery/gallery.component.ts
@@ -31,6 +31,7 @@ import {PhotoFilterPipe} from '../../pipes/PhotoFilterPipe';
 import {MediaButtonModalComponent} from './grid/photo/media-button-modal/media-button-modal.component';
 import {ContentWrapperWithError} from '../../../../common/entities/ContentWrapper';
 import {SearchQueryUtils} from '../../../../common/SearchQueryUtils';
+import {SearchQueryTypes, TextSearch, TextSearchQueryMatchTypes} from '../../../../common/entities/SearchQueryDTO';
 import {UploaderService} from './uploader/uploader.service';
 import {GalleryService} from './gallery.service';
 import {UploaderComponent} from './uploader/uploader.gallery.component';
@@ -161,6 +162,7 @@ export class GalleryComponent implements OnInit, OnDestroy {
 
   async ngOnInit(): Promise<boolean> {
     await this.shareService.wait();
+    await this.authService.waitForSessionUser();
     if (!this.authService.isAuthenticated()) {
       return this.navigation.toLogin();
     }
@@ -234,9 +236,20 @@ export class GalleryComponent implements OnInit, OnDestroy {
       const qParams: { [key: string]: any } = {};
       qParams[QueryParams.gallery.sharingKey_query] =
         this.shareService.getSharingKey();
-      this.router
-        .navigate(['/search', JSON.stringify(sharing.searchQuery)], {queryParams: qParams})
-        .catch(console.error);
+      // For directory shares, use the gallery directory view so subfolders are navigable.
+      // For other query types (date, person, etc.) fall back to the search view.
+      if (
+        sharing.searchQuery?.type === SearchQueryTypes.directory &&
+        (sharing.searchQuery as TextSearch).matchType === TextSearchQueryMatchTypes.exact_match
+      ) {
+        this.router
+          .navigate(['gallery', (sharing.searchQuery as TextSearch).value], {queryParams: qParams})
+          .catch(console.error);
+      } else {
+        this.router
+          .navigate(['/search', JSON.stringify(sharing.searchQuery)], {queryParams: qParams})
+          .catch(console.error);
+      }
       return;
     }
 

--- a/src/frontend/app/ui/gallery/gallery.component.ts
+++ b/src/frontend/app/ui/gallery/gallery.component.ts
@@ -31,6 +31,7 @@ import {PhotoFilterPipe} from '../../pipes/PhotoFilterPipe';
 import {MediaButtonModalComponent} from './grid/photo/media-button-modal/media-button-modal.component';
 import {ContentWrapperWithError} from '../../../../common/entities/ContentWrapper';
 import {SearchQueryUtils} from '../../../../common/SearchQueryUtils';
+import {SearchQueryTypes, TextSearch, TextSearchQueryMatchTypes} from '../../../../common/entities/SearchQueryDTO';
 import {UploaderService} from './uploader/uploader.service';
 import {GalleryService} from './gallery.service';
 import {UploaderComponent} from './uploader/uploader.gallery.component';
@@ -161,6 +162,7 @@ export class GalleryComponent implements OnInit, OnDestroy {
 
   async ngOnInit(): Promise<boolean> {
     await this.shareService.wait();
+    await this.authService.waitForSessionUser();
     if (!this.authService.isAuthenticated()) {
       return this.navigation.toLogin();
     }
@@ -234,9 +236,20 @@ export class GalleryComponent implements OnInit, OnDestroy {
       const qParams: { [key: string]: any } = {};
       qParams[QueryParams.gallery.sharingKey_query] =
         this.shareService.getSharingKey();
-      this.router
-        .navigate(['/search', JSON.stringify(sharing.searchQuery)], {queryParams: qParams})
-        .catch(console.error);
+      // For directory shares use the gallery directory view so subfolders are navigable.
+      // For other query types (date, person, etc.) fall back to the search view.
+      if (
+        sharing.searchQuery?.type === SearchQueryTypes.directory &&
+        (sharing.searchQuery as TextSearch).matchType === TextSearchQueryMatchTypes.exact_match
+      ) {
+        this.router
+          .navigate(['gallery', (sharing.searchQuery as TextSearch).value], {queryParams: qParams})
+          .catch(console.error);
+      } else {
+        this.router
+          .navigate(['/search', JSON.stringify(sharing.searchQuery)], {queryParams: qParams})
+          .catch(console.error);
+      }
       return;
     }
 

--- a/src/frontend/app/ui/gallery/navigator/navigator.gallery.component.ts
+++ b/src/frontend/app/ui/gallery/navigator/navigator.gallery.component.ts
@@ -26,6 +26,7 @@ import { StringifySortingMethod } from '../../../pipes/StringifySortingMethod';
 import { StringifySearchQuery } from '../../../pipes/StringifySearchQuery';
 import { StringifyGridSize } from '../../../pipes/StringifyGridSize';
 import {ContentWrapperWithError} from '../../../../../common/entities/ContentWrapper';
+import {ShareService} from '../share.service';
 
 @Component({
     selector: 'app-gallery-navbar',
@@ -79,7 +80,8 @@ export class GalleryNavigatorComponent {
       public sortingService: GallerySortingService,
       public navigatorService: GalleryNavigatorService,
       private router: Router,
-      public sanitizer: DomSanitizer
+      public sanitizer: DomSanitizer,
+      private shareService: ShareService,
   ) {
     this.sortingByTypes = Utils.enumToArray(SortByTypes);
     // can't group by random
@@ -130,6 +132,8 @@ export class GalleryNavigatorComponent {
 
           const user = this.authService.user.value;
           const arr: NavigatorPath[] = [];
+          // For sharing users, allow navigation within the shared subtree only
+          const shareRootPath = user.role <= UserRoles.LimitedGuest ? this.getShareRootPath() : null;
 
           // create root link
           if (dirs.length === 0) {
@@ -137,9 +141,7 @@ export class GalleryNavigatorComponent {
           } else {
             arr.push({
               name: this.RootFolderName,
-              route: user.role > UserRoles.LimitedGuest // it's basically a sharing. they should not just navigate wherever
-                  ? '/'
-                  : null,
+              route: user.role > UserRoles.LimitedGuest ? '/' : null,
             });
           }
 
@@ -147,15 +149,15 @@ export class GalleryNavigatorComponent {
           dirs.forEach((name, index) => {
             const route = dirs.slice(0, index + 1).join('/');
             if (dirs.length - 1 === index) {
-              arr.push({name, route: null});
+              arr.push({name, route: null}); // current directory is never a link
             } else {
-              arr.push({
-                name,
-                route: user.role > UserRoles.LimitedGuest // it's basically a sharing. they should not just navigate wherever
-                    ? route
-                    : null,
-              });
-
+              let linkRoute: string | null = null;
+              if (user.role > UserRoles.LimitedGuest) {
+                linkRoute = route;
+              } else if (shareRootPath && (route === shareRootPath || route.startsWith(shareRootPath + '/'))) {
+                linkRoute = route;
+              }
+              arr.push({name, route: linkRoute});
             }
           });
 
@@ -336,6 +338,18 @@ export class GalleryNavigatorComponent {
   }
 
   protected readonly GroupByTypes = GroupByTypes;
+
+  private getShareRootPath(): string | null {
+    const sharing = this.shareService.sharingSubject.value;
+    if (!sharing?.searchQuery) {
+      return null;
+    }
+    const sq = sharing.searchQuery as TextSearch;
+    if (sq.type !== SearchQueryTypes.directory || sq.matchType !== TextSearchQueryMatchTypes.exact_match) {
+      return null;
+    }
+    return sq.value.replace(/^\.\//, '').replace(/\\/g, '/');
+  }
 }
 
 interface NavigatorPath {

--- a/src/frontend/app/ui/gallery/navigator/navigator.gallery.component.ts
+++ b/src/frontend/app/ui/gallery/navigator/navigator.gallery.component.ts
@@ -8,7 +8,7 @@ import {Utils} from '../../../../../common/Utils';
 import {GroupByTypes, GroupingMethod, SortByDirectionalTypes, SortByTypes} from '../../../../../common/entities/SortingMethods';
 import {Config} from '../../../../../common/config/public/Config';
 import {SearchQueryDTO, SearchQueryTypes, TextSearch, TextSearchQueryMatchTypes,} from '../../../../../common/entities/SearchQueryDTO';
-import {Observable} from 'rxjs';
+import {combineLatest, Observable} from 'rxjs';
 import {map} from 'rxjs/operators';
 import {GallerySortingService} from './sorting.service';
 import {PageHelper} from '../../../model/page.helper';
@@ -26,6 +26,8 @@ import { StringifySortingMethod } from '../../../pipes/StringifySortingMethod';
 import { StringifySearchQuery } from '../../../pipes/StringifySearchQuery';
 import { StringifyGridSize } from '../../../pipes/StringifyGridSize';
 import {ContentWrapperWithError} from '../../../../../common/entities/ContentWrapper';
+import {ResponseSharingDTO} from '../../../../../common/entities/SharingDTO';
+import {ShareService} from '../share.service';
 
 @Component({
     selector: 'app-gallery-navbar',
@@ -79,7 +81,8 @@ export class GalleryNavigatorComponent {
       public sortingService: GallerySortingService,
       public navigatorService: GalleryNavigatorService,
       private router: Router,
-      public sanitizer: DomSanitizer
+      public sanitizer: DomSanitizer,
+      private shareService: ShareService,
   ) {
     this.sortingByTypes = Utils.enumToArray(SortByTypes);
     // can't group by random
@@ -90,8 +93,13 @@ export class GalleryNavigatorComponent {
     this.directoryContent = this.wrappedContent.pipe(
         map((c) => (c.directory ? c.directory : c.searchResult))
     );
-    this.routes = this.contentLoaderService.content.pipe(
-        map((c) => {
+    // combineLatest ensures routes recompute whenever share metadata arrives,
+    // fixing a race where cached content loads before sharingSubject emits.
+    this.routes = combineLatest([
+      this.contentLoaderService.content,
+      this.shareService.sharingSubject,
+    ]).pipe(
+        map(([c, sharing]) => {
           this.parentPath = null;
           if (!c?.directory && !this.isExactDirectorySearch(c)) {
             return [];
@@ -130,6 +138,7 @@ export class GalleryNavigatorComponent {
 
           const user = this.authService.user.value;
           const arr: NavigatorPath[] = [];
+          const shareRootPath = user.role <= UserRoles.LimitedGuest ? this.getShareRootPath(sharing) : null;
 
           // create root link
           if (dirs.length === 0) {
@@ -137,9 +146,7 @@ export class GalleryNavigatorComponent {
           } else {
             arr.push({
               name: this.RootFolderName,
-              route: user.role > UserRoles.LimitedGuest // it's basically a sharing. they should not just navigate wherever
-                  ? '/'
-                  : null,
+              route: user.role > UserRoles.LimitedGuest ? '/' : null,
             });
           }
 
@@ -149,13 +156,14 @@ export class GalleryNavigatorComponent {
             if (dirs.length - 1 === index) {
               arr.push({name, route: null});
             } else {
-              arr.push({
-                name,
-                route: user.role > UserRoles.LimitedGuest // it's basically a sharing. they should not just navigate wherever
-                    ? route
-                    : null,
-              });
-
+              let linkRoute: string | null = null;
+              if (user.role > UserRoles.LimitedGuest) {
+                linkRoute = route;
+              } else if (shareRootPath !== null && (shareRootPath === '' || route === shareRootPath || route.startsWith(shareRootPath + '/'))) {
+                // shareRootPath==='' means a root-directory share — all subdirectory routes are in scope
+                linkRoute = route;
+              }
+              arr.push({name, route: linkRoute});
             }
           });
 
@@ -336,6 +344,20 @@ export class GalleryNavigatorComponent {
   }
 
   protected readonly GroupByTypes = GroupByTypes;
+
+  /**
+   * Extracts the normalised share-root path from a sharing object, or null for non-directory shares.
+   * Mirrors backend normalizeDirPath: backslashes → '/', trailing slashes stripped, '.' → '' (gallery root).
+   */
+  private getShareRootPath(sharing: ResponseSharingDTO | null): string | null {
+    if (!sharing?.searchQuery) return null;
+    const q = sharing.searchQuery as TextSearch;
+    if (q.type === SearchQueryTypes.directory && q.matchType === TextSearchQueryMatchTypes.exact_match) {
+      const s = q.value.replace(/\\/g, '/').replace(/\/+$/, '');
+      return s === '.' ? '' : s;
+    }
+    return null;
+  }
 }
 
 interface NavigatorPath {

--- a/src/frontend/app/ui/gallery/share.service.ts
+++ b/src/frontend/app/ui/gallery/share.service.ts
@@ -20,6 +20,7 @@ export class ShareService {
   queryParam: string = null;
   sharingKey: string = null;
   inited = false;
+  sharingPasswordProtected: boolean | null = null;
   public ReadyPR: Promise<void>;
   public sharingSubject: BehaviorSubject<ResponseSharingDTO> = new BehaviorSubject(
     null
@@ -65,7 +66,6 @@ export class ShareService {
         }
       }
     });
-    this.currentSharing.subscribe( (sharing) => console.log('sharing', sharing))
   }
 
   public getUrl(share: ResponseSharingDTO): string {
@@ -203,12 +203,15 @@ export class ShareService {
   private async checkSharing(): Promise<void> {
     try {
       this.sharingIsValid.next(null);
+      this.sharingPasswordProtected = null;
       const sharing = await this.networkService.getJson<SharingDTOKey>(
         '/share/' + this.getSharingKey() + '/key'
       );
       this.sharingIsValid.next(sharing.sharingKey === this.getSharingKey());
+      this.sharingPasswordProtected = sharing.passwordProtected ?? null;
     } catch (e) {
       this.sharingIsValid.next(false);
+      this.sharingPasswordProtected = null;
       console.error(e);
     }
   }

--- a/src/frontend/app/ui/gallery/share.service.ts
+++ b/src/frontend/app/ui/gallery/share.service.ts
@@ -32,6 +32,7 @@ export class ShareService {
     .pipe(filter((s) => s !== null))
     .pipe(distinctUntilChanged());
 
+  public sharingPasswordProtected: boolean | null = null;
   private resolve: () => void;
 
   constructor(private networkService: NetworkService, private router: Router) {
@@ -65,7 +66,6 @@ export class ShareService {
         }
       }
     });
-    this.currentSharing.subscribe( (sharing) => console.log('sharing', sharing))
   }
 
   public getUrl(share: ResponseSharingDTO): string {
@@ -206,6 +206,7 @@ export class ShareService {
       const sharing = await this.networkService.getJson<SharingDTOKey>(
         '/share/' + this.getSharingKey() + '/key'
       );
+      this.sharingPasswordProtected = sharing.passwordProtected ?? null;
       this.sharingIsValid.next(sharing.sharingKey === this.getSharingKey());
     } catch (e) {
       this.sharingIsValid.next(false);

--- a/src/frontend/app/ui/gallery/share/share.gallery.component.html
+++ b/src/frontend/app/ui/gallery/share/share.gallery.component.html
@@ -70,7 +70,7 @@
             <span i18n>Sharing</span>&nbsp;<ng-container *ngIf="currentMediaCountIsLowerBound"><span
             i18n>at least</span>&nbsp;
           </ng-container>
-            <span class="fw-bold">{{ currentMediaCount }}</span>&nbsp;<span i18n>photos and videos.</span>&nbsp;<span i18n>Folders are not shared.</span>
+            <span class="fw-bold">{{ currentMediaCount }}</span>&nbsp;<span i18n>photos and videos.</span>
           </small>
         </div>
       </div>

--- a/test/cypress/e2e/share.cy.ts
+++ b/test/cypress/e2e/share.cy.ts
@@ -31,7 +31,7 @@ describe('Share', () => {
 
         cy.intercept({
           method: 'Get',
-          url: '/pgapi/search/*',
+          url: '/pgapi/gallery/content/*',
         }, (req) => {
           // Remove caching headers to force a 200 OK response from the server
           delete req.headers['if-none-match'];
@@ -42,7 +42,7 @@ describe('Share', () => {
         cy.get('button#button-share-login').click();
 
 
-        cy.get('.mb-0 > :nth-child(1) > .nav-link').contains('Gallery');
+        cy.get('#directory-path');
 
         cy.wait('@getSharedContent').then((interception) => {
           expect(interception.response.statusCode).to.eq(200);
@@ -67,7 +67,7 @@ describe('Share', () => {
 
         cy.intercept({
           method: 'Get',
-          url: '/pgapi/search/*',
+          url: '/pgapi/gallery/content/*',
         }, (req) => {
           // Remove caching headers to force a 200 OK response from the server
           delete req.headers['if-none-match'];
@@ -76,7 +76,7 @@ describe('Share', () => {
          cy.visit(link);
 
 
-        cy.get('.mb-0 > :nth-child(1) > .nav-link').contains('Gallery');
+        cy.get('#directory-path');
 
         cy.wait('@getSharedContent').then((interception) => {
           expect(interception.response.statusCode).to.eq(200);
@@ -105,7 +105,7 @@ describe('Share', () => {
 
         cy.intercept({
           method: 'Get',
-          url: '/pgapi/search/*',
+          url: '/pgapi/gallery/content/*',
         }, (req) => {
           // Remove caching headers to force a 200 OK response from the server
           delete req.headers['if-none-match'];
@@ -113,7 +113,7 @@ describe('Share', () => {
         }).as('getSharedContent');
         cy.visit(link);
 
-        cy.get('.mb-0 > :nth-child(1) > .nav-link').contains('Gallery');
+        cy.get('#directory-path');
 
         cy.wait('@getSharedContent').then((interception) => {
           expect(interception.response.statusCode).to.eq(200);

--- a/test/cypress/e2e/share.cy.ts
+++ b/test/cypress/e2e/share.cy.ts
@@ -31,7 +31,7 @@ describe('Share', () => {
 
         cy.intercept({
           method: 'Get',
-          url: '/pgapi/search/*',
+          url: '/pgapi/gallery/content/**',
         }, (req) => {
           // Remove caching headers to force a 200 OK response from the server
           delete req.headers['if-none-match'];
@@ -69,7 +69,7 @@ describe('Share', () => {
 
         cy.intercept({
           method: 'Get',
-          url: '/pgapi/search/*',
+          url: '/pgapi/gallery/content/**',
         }, (req) => {
           // Remove caching headers to force a 200 OK response from the server
           delete req.headers['if-none-match'];
@@ -107,7 +107,7 @@ describe('Share', () => {
 
         cy.intercept({
           method: 'Get',
-          url: '/pgapi/search/*',
+          url: '/pgapi/gallery/content/**',
         }, (req) => {
           // Remove caching headers to force a 200 OK response from the server
           delete req.headers['if-none-match'];


### PR DESCRIPTION
WARNING - This was vibe coded. I am a Java dev, and don't really know typescript. I had a Claude sub so wanted to apply it to this as I  use pigallery2. I have tested (not extensively) via a local build docker image.

 Fix: Subfolder navigation now works for shared folder links

  This fixes the regression reported in Discussion #1068 where shared folder links no longer allowed recipients to browse into subfolders.

  What was broken and what was fixed:

  1. Subfolder visibility (backend) — The sharing projection query in SearchManager only matched the exact shared directory, so subdirectories were invisible to sharing users. Added recursive directory matching so that
  when a folder is shared, all its subdirectories are included in the allowed content projection.
  2. Password-protected share login (frontend + backend) — Visiting a shared link (/share/<key>) with passwordRequired: true produced a blank screen and a spinning loop of 401 errors in the browser console. Two root
  causes:
    - NavigationService.toLogin() was awaiting the currentSharing observable to determine whether to show the password prompt — but that observable only emits after authentication, creating a deadlock. Fixed by exposing
   passwordProtected from the public /share/<key>/key endpoint (no auth required) so the redirect decision can be made synchronously.
    - error.interceptor.ts was calling logout() unconditionally on every HTTP 401, even when the user was already unauthenticated, causing an infinite logout→getSessionUser→401 loop. Fixed to only call logout() when a
  user is actually authenticated; otherwise navigates to the login/share-login page directly.
  3. Directory listing access for sharing users (backend) — After successful share password entry, the gallery content endpoint returned 401 NOT_AUTHORISED. The route required UserRoles.Guest but sharing users are
  assigned UserRoles.LimitedGuest. Changed the role check to LimitedGuest — the existing session projectionQuery already restricts sharing users to only see content within their shared directory, so there is no security
   regression.
  4. Breadcrumb navigation for sharing users (frontend) — Once inside a shared folder, there was no way to navigate back up through the folder hierarchy (only the browser back button worked). The breadcrumb bar now
  renders each folder at or below the share root as a clickable link, while folders above the share root remain plain text so users cannot navigate outside their share. The sharing key is preserved in all breadcrumb
  links automatically.
  5. Share dialog cleanup — Removed the now-inaccurate notice "Folders are not shared." from the share creation dialog.
