### PR TITLE
Play videos inline on hover with audio controls

### DIFF
--- a/src/common/config/public/ClientConfig.ts
+++ b/src/common/config/public/ClientConfig.ts
@@ -1197,6 +1197,14 @@ export class ClientGalleryConfig {
   })
   captionFirstNaming: boolean = false; // shows the caption instead of the filename in the photo grid
 
+  @ConfigProperty({
+    tags: {
+      name: $localize`Play videos on hover`,
+      priority: ConfigPriority.advanced,
+    },
+    description: $localize`Plays video inline in the gallery grid when hovering the card (desktop) or long-pressing (mobile).`
+  })
+  playVideoOnHover: boolean = true;
 
   @ConfigProperty({
     tags: {

--- a/src/frontend/app/ui/gallery/grid/photo/photo.grid.gallery.component.css
+++ b/src/frontend/app/ui/gallery/grid/photo/photo.grid.gallery.component.css
@@ -235,9 +235,9 @@ a {
   background: rgba(0, 0, 0, 0.5);
   border: none;
   border-radius: 50%;
-  width: 32px;
-  height: 32px;
-  padding: 6px;
+  width: 40px;
+  height: 40px;
+  padding: 0;
   cursor: pointer;
   color: white;
   display: flex;
@@ -245,6 +245,10 @@ a {
   justify-content: center;
   z-index: 5;
   transition: background-color 0.2s ease;
+}
+
+.video-mute-btn ng-icon {
+  font-size: 24px;
 }
 
 .video-mute-btn:hover {

--- a/src/frontend/app/ui/gallery/grid/photo/photo.grid.gallery.component.css
+++ b/src/frontend/app/ui/gallery/grid/photo/photo.grid.gallery.component.css
@@ -212,3 +212,18 @@ a {
 .no-click {
   cursor: auto;
 }
+
+.hover-video {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  opacity: 0;
+  transition: opacity 0.3s ease-in-out;
+}
+
+.hover-video.visible {
+  opacity: 1;
+}

--- a/src/frontend/app/ui/gallery/grid/photo/photo.grid.gallery.component.css
+++ b/src/frontend/app/ui/gallery/grid/photo/photo.grid.gallery.component.css
@@ -227,3 +227,26 @@ a {
 .hover-video.visible {
   opacity: 1;
 }
+
+.video-mute-btn {
+  position: absolute;
+  bottom: 8px;
+  right: 8px;
+  background: rgba(0, 0, 0, 0.5);
+  border: none;
+  border-radius: 50%;
+  width: 32px;
+  height: 32px;
+  padding: 6px;
+  cursor: pointer;
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 5;
+  transition: background-color 0.2s ease;
+}
+
+.video-mute-btn:hover {
+  background: rgba(0, 0, 0, 0.8);
+}

--- a/src/frontend/app/ui/gallery/grid/photo/photo.grid.gallery.component.html
+++ b/src/frontend/app/ui/gallery/grid/photo/photo.grid.gallery.component.html
@@ -1,4 +1,8 @@
-<div #photoContainer class="photo-container rounded" (mouseover)="mouseOver()" (mouseout)="mouseOut()">
+<div #photoContainer class="photo-container rounded"
+     (mouseover)="mouseOver()" (mouseout)="mouseOut()"
+     (mouseenter)="onMouseEnterCard()" (mouseleave)="onMouseLeaveCard()"
+     (touchstart)="onTouchStart()" (touchend)="onTouchEnd()"
+     (touchcancel)="onTouchEnd()">
 
 
   <img alt="{{gridMedia.media.name}}" #img [src]="thumbnail.Src"
@@ -12,6 +16,14 @@
     *ngIf="!thumbnail.Available">
   </app-gallery-grid-photo-loading>
 
+  <video #hoverVideo
+         *ngIf="gridMedia.isVideo() && Config.Gallery.playVideoOnHover"
+         [class.visible]="videoPlaying"
+         class="hover-video"
+         muted
+         loop
+         playsinline>
+  </video>
 
   <div *ngIf="gridMedia.isVideo()" class="video-indicator">
     {{gridMedia.Video.metadata.duration  | duration}}

--- a/src/frontend/app/ui/gallery/grid/photo/photo.grid.gallery.component.html
+++ b/src/frontend/app/ui/gallery/grid/photo/photo.grid.gallery.component.html
@@ -25,6 +25,12 @@
          playsinline>
   </video>
 
+  <button *ngIf="videoPlaying"
+          class="video-mute-btn"
+          (click)="toggleVideoMute($event)">
+    <ng-icon [name]="videoMuted ? 'ionVolumeMuteOutline' : 'ionVolumeMediumOutline'"></ng-icon>
+  </button>
+
   <div *ngIf="gridMedia.isVideo()" class="video-indicator">
     {{gridMedia.Video.metadata.duration  | duration}}
     <ng-icon name="ionVideocamOutline"></ng-icon>

--- a/src/frontend/app/ui/gallery/grid/photo/photo.grid.gallery.component.ts
+++ b/src/frontend/app/ui/gallery/grid/photo/photo.grid.gallery.component.ts
@@ -1,4 +1,7 @@
 import {Component, ElementRef, Input, OnDestroy, OnInit, ViewChild,} from '@angular/core';
+
+// Persists for the lifetime of the page — shared across all card instances
+let globalVideoMuted = true;
 import {Dimension, IRenderable} from '../../../../model/IRenderable';
 import {GridMedia} from '../GridMedia';
 import {RouterLink} from '@angular/router';
@@ -322,6 +325,20 @@ export class GalleryPhotoComponent implements IRenderable, OnInit, OnDestroy {
     this.stopHoverVideo();
   }
 
+  get videoMuted(): boolean {
+    return globalVideoMuted;
+  }
+
+  toggleVideoMute(event: Event): void {
+    event.stopPropagation();
+    event.preventDefault();
+    globalVideoMuted = !globalVideoMuted;
+    const video = this.hoverVideoRef?.nativeElement;
+    if (video) {
+      video.muted = globalVideoMuted;
+    }
+  }
+
   private async startHoverVideo(): Promise<void> {
     const video = this.hoverVideoRef?.nativeElement;
     if (!video) return;
@@ -329,6 +346,7 @@ export class GalleryPhotoComponent implements IRenderable, OnInit, OnDestroy {
       video.src = this.gridMedia.getBestFitVideoPath();
       this.videoSrcLoaded = true;
     }
+    video.muted = globalVideoMuted;
     try {
       await video.play();
       if (!video.paused) {

--- a/src/frontend/app/ui/gallery/grid/photo/photo.grid.gallery.component.ts
+++ b/src/frontend/app/ui/gallery/grid/photo/photo.grid.gallery.component.ts
@@ -43,6 +43,9 @@ export class GalleryPhotoComponent implements IRenderable, OnInit, OnDestroy {
   @Input() gridMedia: GridMedia;
   @ViewChild('img', {static: false}) imageRef: ElementRef;
   @ViewChild('photoContainer', {static: true}) container: ElementRef;
+  @ViewChild('hoverVideo', {static: false}) hoverVideoRef: ElementRef<HTMLVideoElement>;
+
+  protected readonly Config = Config;
 
   thumbnail: Thumbnail;
   keywords: { value: string; type: SearchQueryTypes }[] = null;
@@ -54,6 +57,10 @@ export class GalleryPhotoComponent implements IRenderable, OnInit, OnDestroy {
 
   wasInView: boolean = null;
   loaded = false;
+  videoPlaying = false;
+  private videoSrcLoaded = false;
+  private hoverTimer: number = null;
+  private touchHoverTimer: number = null;
   public mediaButtons: IClientMediaButtonConfigWithBaseApiPath[];
 
   constructor(
@@ -195,6 +202,9 @@ export class GalleryPhotoComponent implements IRenderable, OnInit, OnDestroy {
     if (this.animationTimer != null) {
       clearTimeout(this.animationTimer);
     }
+    if (this.hoverTimer != null) clearTimeout(this.hoverTimer);
+    if (this.touchHoverTimer != null) clearTimeout(this.touchHoverTimer);
+    this.stopHoverVideo();
   }
 
   isInView(): boolean {
@@ -276,6 +286,65 @@ export class GalleryPhotoComponent implements IRenderable, OnInit, OnDestroy {
     } else {
       this.modalService.executeButtonAction(button, this.gridMedia);
     }
+  }
+
+  onMouseEnterCard(): void {
+    if (!Config.Gallery.playVideoOnHover || !this.gridMedia.isVideo()) return;
+    if (this.hoverTimer != null) clearTimeout(this.hoverTimer);
+    this.hoverTimer = window.setTimeout(() => {
+      this.hoverTimer = null;
+      this.startHoverVideo();
+    }, 300);
+  }
+
+  onMouseLeaveCard(): void {
+    if (this.hoverTimer != null) {
+      clearTimeout(this.hoverTimer);
+      this.hoverTimer = null;
+    }
+    this.stopHoverVideo();
+  }
+
+  onTouchStart(): void {
+    if (!Config.Gallery.playVideoOnHover || !this.gridMedia.isVideo()) return;
+    if (this.touchHoverTimer != null) clearTimeout(this.touchHoverTimer);
+    this.touchHoverTimer = window.setTimeout(() => {
+      this.touchHoverTimer = null;
+      this.startHoverVideo();
+    }, 600);
+  }
+
+  onTouchEnd(): void {
+    if (this.touchHoverTimer != null) {
+      clearTimeout(this.touchHoverTimer);
+      this.touchHoverTimer = null;
+    }
+    this.stopHoverVideo();
+  }
+
+  private async startHoverVideo(): Promise<void> {
+    const video = this.hoverVideoRef?.nativeElement;
+    if (!video) return;
+    if (!this.videoSrcLoaded) {
+      video.src = this.gridMedia.getBestFitVideoPath();
+      this.videoSrcLoaded = true;
+    }
+    try {
+      await video.play();
+      if (!video.paused) {
+        this.videoPlaying = true;
+      }
+    } catch {
+      // play() aborted (e.g., mouse left before video loaded)
+    }
+  }
+
+  private stopHoverVideo(): void {
+    this.videoPlaying = false;
+    const video = this.hoverVideoRef?.nativeElement;
+    if (!video) return;
+    video.pause();
+    video.currentTime = 0;
   }
 
   public getDimension(): Dimension {


### PR DESCRIPTION
Adds the ability to play videos inline within gallery grid cards when hovering. There is a new option to enable/disable this feature, in the advanced section. There is also support for the audio, muted by default, that show a small icon to unmute/mute again in the bottom-right corner of the card (very similar to Instagram reel).

<img width="534" height="358" alt="image" src="https://github.com/user-attachments/assets/d5d56355-19bd-43f8-a66e-e268014a8d71" />
