### PR TITLE
fix: use ceiling-match instead of closest-match for thumbnail/preview size selection

### DIFF
--- a/src/common/Utils.ts
+++ b/src/common/Utils.ts
@@ -413,6 +413,21 @@ export class Utils {
     return curr;
   }
 
+  /**
+   * Returns the first element in the sorted array that is >= num.
+   * If all elements are smaller than num, returns the largest element.
+   * This is the "ceiling" behavior, useful for selecting thumbnail/preview sizes
+   * where you want the next available size up (e.g., for lightbox full-screen display).
+   */
+  public static findCeilinginSorted(num: number, arr: number[]): number {
+    for (const item of arr) {
+      if (item >= num) {
+        return item;
+      }
+    }
+    return arr[arr.length - 1];
+  }
+
   public static asciiToUTF8(text: string): string {
     if (text) {
       // Check for corrupted IPTC data - very long strings with binary content indicate corruption

--- a/src/frontend/app/ui/gallery/MediaIcon.ts
+++ b/src/frontend/app/ui/gallery/MediaIcon.ts
@@ -86,7 +86,7 @@ export class MediaIcon {
 
   getMediaSize(renderWidth: number, renderHeight: number): number {
     const longerEdge = Math.max(renderWidth, renderHeight);
-    return Utils.findClosestinSorted(longerEdge, MediaIcon.sortedThumbnailSizes);
+    return Utils.findCeilinginSorted(longerEdge, MediaIcon.sortedThumbnailSizes);
   }
 
   /**


### PR DESCRIPTION
## Problem
When selecting a thumbnail/preview size, `findClosestinSorted` picks the numerically closest value. For grid thumbnails this is fine, but for lightbox full-screen preview the expected behavior is **ceiling**: pick the next available size that is ≥ the display viewport.

### Example scenario
- Device: 3200×2136px screen with DPR=2 → CSS viewport ~1600px
- Configured sizes: `[320, 1200, 2136, 2160]`
- **Current behavior (bug):** Picks **1200px**, because `|1600-1200|=400 < |1600-2136|=536`
- **Expected behavior:** Picks **2136px**, the smallest size ≥ 1600

## Changes
1. Added `Utils.findCeilinginSorted()` in `src/common/Utils.ts` — returns the first element ≥ num in a sorted array
2. Changed `MediaIcon.getMediaSize()` in `src/frontend/app/ui/gallery/MediaIcon.ts` to use `findCeilinginSorted` instead of `findClosestinSorted`
3. `findClosestinSorted` is preserved for backward compatibility

## Testing
- Grid thumbnail rendering (small render dimensions ~200-300px): ceiling picks the smallest size (e.g., 320px), same as before
- Lightbox full-screen preview: correctly picks the next size up from viewport dimensions
- High-DPI mobile devices: no longer get undersized preview images