### PR TITLE
Support glob wildcards in excludeFolderList

### DIFF
--- a/src/backend/model/fileaccess/DiskManager.ts
+++ b/src/backend/model/fileaccess/DiskManager.ts
@@ -104,7 +104,7 @@ export class DiskManager {
           return true;
         }
       } else {
-        if (exclude === dir.name) {
+        if (DiskManager.globToRegex(exclude).test(dir.name)) {
           return true;
         }
       }

--- a/src/common/config/private/PrivateConfig.ts
+++ b/src/common/config/private/PrivateConfig.ts
@@ -640,7 +640,7 @@ export class ServerIndexingConfig {
         uiOptional: true,
         uiAllowSpaces: true
       } as TAGS,
-    description: $localize`Folders to exclude from indexing. If an entry starts with '/' it is treated as an absolute path. If it doesn't start with '/' but contains a '/', the path is relative to the image directory. If it doesn't contain a '/', any folder with this name will be excluded.`,
+    description: $localize`Folders to exclude from indexing. If an entry starts with '/' it is treated as an absolute path. If it doesn't start with '/' but contains a '/', the path is relative to the image directory. If it doesn't contain a '/', any folder whose name matches will be excluded; this supports '*' (any characters) and '?' (single character) wildcards.`,
   })
   excludeFolderList: string[] = ['.Trash-1000', '.dtrash', '$RECYCLE.BIN'];
   @ConfigProperty({

--- a/test/backend/unit/model/threading/DiskManagerWorker.spec.ts
+++ b/test/backend/unit/model/threading/DiskManagerWorker.spec.ts
@@ -95,4 +95,39 @@ describe('DiskMangerWorker', () => {
       expect(dir.media.length).to.be.equals(18);
     });
   });
+
+  describe('excludeFolderList', () => {
+    const savedExcludeFolderList = Config.Indexing.excludeFolderList;
+
+    afterEach(() => {
+      Config.Indexing.excludeFolderList = savedExcludeFolderList;
+    });
+
+    const callExcludeDir = (name: string): Promise<boolean> =>
+      DiskManager.excludeDir({
+        name,
+        parentDirRelativeName: '.',
+        parentDirAbsoluteName: path.join(__dirname, '/../../../assets')
+      });
+
+    it('excludeDir should still match plain folder names exactly', async () => {
+      Config.Indexing.excludeFolderList = ['.dtrash'];
+      expect(await callExcludeDir('.dtrash')).to.be.true;
+      expect(await callExcludeDir('photos')).to.be.false;
+    });
+
+    it('excludeDir should exclude folders using glob pattern "*"', async () => {
+      Config.Indexing.excludeFolderList = ['temp*'];
+      expect(await callExcludeDir('temp')).to.be.true;
+      expect(await callExcludeDir('temp2024')).to.be.true;
+      expect(await callExcludeDir('photos')).to.be.false;
+    });
+
+    it('excludeDir should support "?" wildcard for single character', async () => {
+      Config.Indexing.excludeFolderList = ['202?'];
+      expect(await callExcludeDir('2020')).to.be.true;
+      expect(await callExcludeDir('202')).to.be.false;
+      expect(await callExcludeDir('20200')).to.be.false;
+    });
+  });
 });


### PR DESCRIPTION
Fixes #192.

`excludeFolderList` only matched folder names exactly, so there was no way to exclude e.g. all `temp*` folders at once. This makes the no-slash case match with glob patterns (`*` and `?`), reusing the same `globToRegex` helper the filename exclude list already uses. Names without wildcards still match exactly, so the existing defaults (`.dtrash`, `$RECYCLE.BIN`, ...) keep working as before.

Added unit tests for the glob matching and the plain-name case, and updated the setting description to mention the wildcards. The DiskManagerWorker spec passes.