### PR TITLE
Wrong share link generated when using different base URL

### DIFF
--- a/src/frontend/app/ui/gallery/share.service.ts
+++ b/src/frontend/app/ui/gallery/share.service.ts
@@ -69,7 +69,7 @@ export class ShareService {
   }
 
   public getUrl(share: ResponseSharingDTO): string {
-    return Utils.concatUrls(Config.Server.publicUrl, '/share/', share.sharingKey);
+    return Utils.concatUrls(Config.Server.publicUrl, Config.Server.urlBase, '/share/', share.sharingKey);
   }
 
 


### PR DESCRIPTION
Steps to reproduce:
- host pigallery2 under a different base url (other than "/") and configure it in the settings
- generate a "share" link, it won't contain the base url in the link and thus it cannot be reached.

For example:
- full address "http://foo.moo/bird"
- pigallery2 generated share link will be "http://foo.moo/share/xyz1234" which will not work
- if you manually change it to "http://foo.moo/bird/share/xyz1234" then it works