### PR TITLE
Make boolean search keywords case-insensitive

### DIFF
--- a/src/common/SearchQueryParser.ts
+++ b/src/common/SearchQueryParser.ts
@@ -218,8 +218,13 @@ export class SearchQueryParser {
     // tokenize
     const tokenEnd = fistSpace();
 
+    // case-insensitive variant of str.startsWith(search, pos) so that
+    // boolean keywords (e.g. `or` vs `OR`) are matched regardless of casing
+    const startsWithI = (search: string, pos: number): boolean =>
+      str.slice(pos, pos + search.length).toLowerCase() === search.toLowerCase();
+
     if (tokenEnd !== str.length - 1) {
-      if (str.startsWith(' ' + this.keywords.and, tokenEnd)) {
+      if (startsWithI(' ' + this.keywords.and, tokenEnd)) {
         const rest = this.parse(
           str.slice(tokenEnd + (' ' + this.keywords.and).length),
           implicitAND
@@ -233,7 +238,7 @@ export class SearchQueryParser {
               : [rest]),
           ],
         } as ANDSearchQuery;
-      } else if (str.startsWith(' ' + this.keywords.or, tokenEnd)) {
+      } else if (startsWithI(' ' + this.keywords.or, tokenEnd)) {
         const rest = this.parse(
           str.slice(tokenEnd + (' ' + this.keywords.or).length),
           implicitAND

--- a/test/common/unit/SearchQueryParser.spec.ts
+++ b/test/common/unit/SearchQueryParser.spec.ts
@@ -118,6 +118,14 @@ describe('SearchQueryParser', () => {
       reverseCheck('3-of:(a d v)');
     });
 
+    it('boolean keywords should be case-insensitive', () => {
+      equalCheck('a or b', 'a OR b');
+      equalCheck('a and b', 'a AND b');
+      equalCheck('a or b', 'a Or b');
+      equalCheck('directory:(some text) or any-text:(some other)', 'directory:(some text) OR any-text:(some other)');
+      equalCheck('directory:(some text) and any-text:(some other)', 'directory:(some text) AND any-text:(some other)');
+    });
+
   });
 
   describe('should deserialize and serialize', () => {


### PR DESCRIPTION
Fixes #1090

The query parser only matched the `and`/`or` boolean keywords with exact casing, so `OR` and `AND` (or mixed case like `Or`) weren't recognised. I added a small case-insensitive variant of `startsWith` and use it when matching those keywords during tokenization.

Added a unit test covering the case-insensitive variants. The SearchQueryParser unit tests pass locally (19 passing).