### PR TITLE
Support manual-install extension listings

### DIFF
--- a/src/common/entities/extension/ExtensionListItem.ts
+++ b/src/common/entities/extension/ExtensionListItem.ts
@@ -3,6 +3,6 @@ export interface ExtensionListItem {
   name: string;
   url?: string;
   readme?: string;
-  zipUrl: string;
+  zipUrl?: string;
   installed?: boolean;
 }

--- a/src/frontend/app/ui/settings/extension-installer/extension-installer.component.html
+++ b/src/frontend/app/ui/settings/extension-installer/extension-installer.component.html
@@ -49,13 +49,22 @@
                 <td>{{ extension.readme || 'No description available' }}</td>
                 <td>
                   <button
-                    *ngIf="!extension.installed"
+                    *ngIf="!extension.installed && extension.zipUrl"
                     class="btn btn-sm btn-primary"
                     (click)="installExtension(extension)"
                     [disabled]="loading"
                     i18n>
                     Install
                   </button>
+                  <a
+                    *ngIf="!extension.installed && !extension.zipUrl && extension.url"
+                    class="btn btn-sm btn-outline-primary"
+                    [href]="extension.url"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    i18n>
+                    Manual installation
+                  </a>
                   <span *ngIf="extension.installed" class="badge bg-success" i18n>Installed</span>
                 </td>
               </tr>

--- a/test/backend/unit/model/extension/ExtensionRepository.spec.ts
+++ b/test/backend/unit/model/extension/ExtensionRepository.spec.ts
@@ -19,4 +19,18 @@ describe('ExtensionRepository', () => {
     const extensions = (new ExtensionRepository()).repoMD(text);
     expect(extensions[0].id).to.deep.equal('sample-extension');
   });
+
+  it('should parse a manual-install extension without a zip URL', () => {
+    const text = `# Pigallery2 extension repository
+
+|     **Name**     | **Url** | **Readme** | **Download** |   |
+|:----------------:|:--------:|:----------:|:------------:|---|
+| Manual extension | [manual](https://example.com/manual) | [README.md](https://example.com/readme) | |   |`;
+    const extensions = (new ExtensionRepository()).repoMD(text);
+
+    expect(extensions).to.have.length(1);
+    expect(extensions[0].id).to.equal('manual-extension');
+    expect(extensions[0].url).to.equal('https://example.com/manual');
+    expect(extensions[0].zipUrl).to.equal(undefined);
+  });
 });


### PR DESCRIPTION
## Summary

- allow extension repository entries without a ZIP URL
- show a **Manual installation** link for those entries instead of a broken Install action
- add parser coverage for a manual-install entry

## Why

Some extensions need host-side setup that PiGallery2's ZIP installer cannot perform. For example, [PiGallery2 Curation Requests](https://github.com/v-marinkov/pigallery2-curation-requests) includes a persistent SQLite workflow, a frontend loader, Docker mounts, and trusted-host review/deletion commands. Advertising a normal branch ZIP would produce an incomplete installation.

This PR adds the generic UI capability first. The repository file is fetched live from master, including by older PiGallery2 releases whose UI still assumes every entry has a ZIP. Adding an empty-Download listing in the same PR would therefore expose a broken Install button to those existing versions.

After this support ships in a PiGallery2 release, I will open a small follow-up PR adding Curation Requests to extension/REPOSITORY.md with an empty Download cell. Supported clients will then direct users to its documented .env-driven install.sh workflow.

## Testing

    npm run test-backend -- --grep ExtensionRepository

Result: 2 passing.