### PR TITLE
fix issue#1186: iOS 15.8 Safari does not support class static blocks

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,7 @@
+last 2 Chrome versions
+last 1 Firefox version
+last 2 Edge major versions
+last 2 Safari major versions
+Firefox ESR
+iOS >= 15
+Safari >= 15


### PR DESCRIPTION
The issue is:

tsconfig.app.json targets ES2022, which outputs class static initialization blocks (static { })
iOS 15.8 Safari (version 15.x) does not support class static blocks — that was added in Safari 16.4

Angular 19 (used here) uses class static blocks internally for Angular's ɵfac factory functions. When compiled to ES2022 target with no browserslist for iOS 15, the JS crashes silently in Safari 15, leaving only the loading screen.

The fix is to add a .browserslistrc that includes iOS >= 15, which tells the Babel-based webpack build to transpile unsupported ES2022 features (like static class blocks) down to ES2015-compatible equivalents.